### PR TITLE
Fix pwa icon not showing on ipad home screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,8 @@
     <meta name="apple-mobile-web-app-title" content="Pizarra Fútbol" />
     
     <!-- Apple Touch Icons -->
-    <link rel="apple-touch-icon" href="/icons/icon-192.png" />
-    <link rel="apple-touch-icon" sizes="152x152" href="/icons/icon-192.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-192.png" />
-    <link rel="apple-touch-icon" sizes="167x167" href="/icons/icon-192.png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     
     <!-- Manifest -->
     <link rel="manifest" href="/manifest.webmanifest" />


### PR DESCRIPTION
Update `apple-touch-icon` references in `index.html` to point to `/apple-touch-icon.png` to fix incorrect icon display and installation on iOS 'Add to Home Screen'.

iOS ignores the manifest for the home screen icon and relies on the `apple-touch-icon` links. The previous configuration was pointing these links to a generic icon, causing the iPad to display a white icon or fail to install it. This change ensures iOS correctly picks up the dedicated `apple-touch-icon.png`.

---
<a href="https://cursor.com/background-agent?bcId=bc-41934aad-2e58-49a9-8d0a-84e6590021ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41934aad-2e58-49a9-8d0a-84e6590021ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

