### PR TITLE
Remove top center button

### DIFF
--- a/src/hooks/useZoomPan.ts
+++ b/src/hooks/useZoomPan.ts
@@ -64,13 +64,8 @@ export const useZoomPan = (svgRef: React.RefObject<SVGSVGElement>) => {
     const touches = Array.from(touchEvent.touches);
     
     if (touches.length === 1) {
-      // Single touch - check for double tap
+      // Single touch - just update touch state
       const now = Date.now();
-      if (now - touchState.lastTapTime < 300) {
-        // Double tap - reset zoom
-        setZoom(1);
-        setPan({ x: 0, y: 0 });
-      }
       
       setTouchState(prev => ({
         ...prev,


### PR DESCRIPTION
Remove double-tap gesture that reset zoom and centered the view.

The user requested to remove the "center button" functionality, which was identified as the double-tap gesture that reset the zoom and centered the view.

---
<a href="https://cursor.com/background-agent?bcId=bc-09c00f71-c67f-40fb-b4eb-bb4032f4cb98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09c00f71-c67f-40fb-b4eb-bb4032f4cb98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

