### PR TITLE
Remove centering button from toolbar

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -21,7 +21,6 @@ export const Toolbar: React.FC<ToolbarProps> = ({ svgRef, onAddToken, onShowPres
     setTrajectoryType,
     toggleGridSnap,
     toggleFullField,
-    resetView,
     reset,
     mirror,
     undo,
@@ -142,13 +141,6 @@ export const Toolbar: React.FC<ToolbarProps> = ({ svgRef, onAddToken, onShowPres
           onClick={toggleGridSnap}
         >
           📐 Rejilla
-        </button>
-        <button
-          className="btn btn-secondary text-sm"
-          onClick={resetView}
-          title="Resetear zoom y posición del campo"
-        >
-          🎯 Centrar
         </button>
       </div>
       


### PR DESCRIPTION
## Summary
- Remove "Centrar" reset view button from the toolbar
- Drop unused `resetView` dependency in toolbar state

## Testing
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b3cccf5b808329a2e9330a9ae24d4f