### PR TITLE
Activar botón mover al colocar objeto

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ function App() {
     pan,
     showFullField,
     gridSnap,
+    drawingMode,
 
     addToken,
     addObject,
@@ -40,6 +41,7 @@ function App() {
     updateArrow,
     selectTrajectory,
     updateTrajectory,
+    setDrawingMode,
     load,
   } = useBoardStore();
   
@@ -88,7 +90,6 @@ function App() {
     // isDrawing, // Not used in current implementation
     color: drawColor,
     // lineStyle: drawLineStyle, // Not used with new mode system
-    drawingMode,
     canUndo: canUndoDraw,
     canRedo: canRedoDraw,
     startDrawing,
@@ -98,9 +99,8 @@ function App() {
     redo: redoDraw,
     setColor: setDrawColor,
     // setLineStyle: setDrawLineStyle, // Not used with new mode system
-    setDrawingMode,
     clearCanvas,
-  } = useSimpleDrawing(canvasRef);
+  } = useSimpleDrawing(canvasRef, drawingMode);
   
     // Handle container resize with PWA detection
   useEffect(() => {
@@ -185,18 +185,12 @@ function App() {
     position = clampToField(position, viewBoxWidth, fieldHeight);
     
     addToken(team, position.x, position.y);
-    
-    // Automatically switch to move mode after adding a token
-    setDrawingMode('move');
-  }, [addToken, showFullField, fieldWidth, fieldHeight, viewBoxWidth, gridSnap, setDrawingMode]);
+  }, [addToken, showFullField, fieldWidth, fieldHeight, viewBoxWidth, gridSnap]);
 
   // Handle formation application
   const handleApplyFormation = useCallback((team: Team, formation: string) => {
     applyFormationByName(formation, team);
-    
-    // Automatically switch to move mode after applying formation
-    setDrawingMode('move');
-  }, [applyFormationByName, setDrawingMode]);
+  }, [applyFormationByName]);
 
   // Handle adding objects
   const handleAddObject = useCallback((type: ObjectType) => {
@@ -213,10 +207,7 @@ function App() {
     position = clampToField(position, viewBoxWidth, fieldHeight);
     
     addObject(type, position.x, position.y);
-    
-    // Automatically switch to move mode after adding an object
-    setDrawingMode('move');
-  }, [addObject, showFullField, fieldWidth, fieldHeight, viewBoxWidth, gridSnap, setDrawingMode]);
+  }, [addObject, showFullField, fieldWidth, fieldHeight, viewBoxWidth, gridSnap]);
 
   // Handle canvas pointer down - no double tap for lines
   const handleCanvasPointerDown = useCallback((e: any) => {

--- a/src/hooks/useBoardStore.ts
+++ b/src/hooks/useBoardStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { BoardState, Token, Arrow, Trajectory, Team, Formation, HistoryState, ObjectType } from '../types';
+import { BoardState, Token, Arrow, Trajectory, Team, Formation, HistoryState, ObjectType, DrawingMode } from '../types';
 import { loadFromStorage, saveToStorage } from '../lib/localStorage';
 
 interface BoardStore extends BoardState {
@@ -29,6 +29,7 @@ interface BoardStore extends BoardState {
   setMode: (mode: BoardState['mode']) => void;
   setArrowStyle: (style: 'solid' | 'dashed') => void;
   setTrajectoryType: (type: 'pass' | 'movement') => void;
+  setDrawingMode: (mode: DrawingMode) => void;
   
   // View actions
   setZoom: (zoom: number) => void;
@@ -62,6 +63,7 @@ const initialState: BoardState = {
   mode: 'select',
   arrowStyle: 'solid',
   trajectoryType: 'pass',
+  drawingMode: 'move',
   gridSnap: false,
   zoom: 1,
   pan: { x: 0, y: 0 },
@@ -137,6 +139,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
         ...state,
         tokens: [...state.tokens, newToken],
         selectedTokenId: newToken.id,
+        drawingMode: 'move' as DrawingMode,
       };
       
       set({
@@ -161,6 +164,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
         ...state,
         tokens: [...state.tokens, newToken],
         selectedTokenId: newToken.id,
+        drawingMode: 'move' as DrawingMode,
       };
       
       set({
@@ -328,6 +332,10 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
     setTrajectoryType: (trajectoryType: 'pass' | 'movement') => {
       set({ trajectoryType });
     },
+
+    setDrawingMode: (drawingMode: DrawingMode) => {
+      set({ drawingMode });
+    },
     
     setZoom: (zoom: number) => {
       set({ zoom: Math.max(0.5, Math.min(3, zoom)) });
@@ -459,6 +467,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
         ...state,
         tokens: [...otherTokens, ...formationTokens],
         selectedTokenId: null,
+        drawingMode: 'move' as DrawingMode,
       };
       
       set({
@@ -518,6 +527,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
         mode: state.mode,
         arrowStyle: state.arrowStyle,
         trajectoryType: state.trajectoryType,
+        drawingMode: state.drawingMode,
         gridSnap: state.gridSnap,
         zoom: state.zoom,
         pan: state.pan,
@@ -594,6 +604,7 @@ useBoardStore.subscribe((state) => {
     mode: state.mode,
     arrowStyle: state.arrowStyle,
     trajectoryType: state.trajectoryType,
+    drawingMode: state.drawingMode,
     gridSnap: state.gridSnap,
     zoom: state.zoom,
     pan: state.pan,

--- a/src/hooks/useSimpleDrawing.ts
+++ b/src/hooks/useSimpleDrawing.ts
@@ -8,10 +8,9 @@ interface DrawingState {
   color: string;
   lineStyle: 'solid' | 'dashed';
   currentPath: { x: number; y: number }[];
-  drawingMode: DrawingMode;
 }
 
-export const useSimpleDrawing = (canvasRef: React.RefObject<HTMLCanvasElement>) => {
+export const useSimpleDrawing = (canvasRef: React.RefObject<HTMLCanvasElement>, drawingMode: DrawingMode) => {
   const [state, setState] = useState<DrawingState>({
     isDrawing: false,
     history: [],
@@ -19,7 +18,6 @@ export const useSimpleDrawing = (canvasRef: React.RefObject<HTMLCanvasElement>) 
     color: 'white',
     lineStyle: 'solid',
     currentPath: [],
-    drawingMode: 'move',
   });
 
   const lastPointRef = useRef<{ x: number; y: number } | null>(null);
@@ -79,7 +77,7 @@ export const useSimpleDrawing = (canvasRef: React.RefObject<HTMLCanvasElement>) 
   }, [canvasRef]);
 
   const startDrawing = useCallback((e: any) => {
-    if (!canvasRef.current || state.drawingMode === 'move') return;
+    if (!canvasRef.current || drawingMode === 'move') return;
     
     e.preventDefault();
     e.stopPropagation();
@@ -88,7 +86,7 @@ export const useSimpleDrawing = (canvasRef: React.RefObject<HTMLCanvasElement>) 
     const ctx = canvasRef.current.getContext('2d');
     if (!ctx) return;
 
-    console.log('🎨 Starting drawing at:', coords, 'Color:', state.color, 'Mode:', state.drawingMode);
+    console.log('🎨 Starting drawing at:', coords, 'Color:', state.color, 'Mode:', drawingMode);
 
     setState(prev => ({ 
       ...prev, 
@@ -106,7 +104,7 @@ export const useSimpleDrawing = (canvasRef: React.RefObject<HTMLCanvasElement>) 
     }
     
     console.log('✅ Drew starting point');
-  }, [canvasRef, getCoords, state.color, state.lineStyle, state.drawingMode]);
+  }, [canvasRef, getCoords, state.color, state.lineStyle, drawingMode]);
 
   const draw = useCallback((e: any) => {
     if (!state.isDrawing || !canvasRef.current || !lastPointRef.current) return;
@@ -125,7 +123,7 @@ export const useSimpleDrawing = (canvasRef: React.RefObject<HTMLCanvasElement>) 
       currentPath: newPath
     }));
 
-    if (state.drawingMode === 'pass') {
+    if (drawingMode === 'pass') {
       // For solid lines, draw immediately
       if (state.color === 'transparent') {
         // Eraser mode
@@ -148,7 +146,7 @@ export const useSimpleDrawing = (canvasRef: React.RefObject<HTMLCanvasElement>) 
       ctx.moveTo(lastPointRef.current.x, lastPointRef.current.y);
       ctx.lineTo(coords.x, coords.y);
       ctx.stroke();
-    } else if (state.drawingMode === 'displacement') {
+    } else if (drawingMode === 'displacement') {
       // For transparent color (eraser), treat it like solid lines to avoid clearing canvas
       if (state.color === 'transparent') {
         // Eraser mode - draw like solid lines but with eraser effect
@@ -211,7 +209,7 @@ export const useSimpleDrawing = (canvasRef: React.RefObject<HTMLCanvasElement>) 
     }
     
     lastPointRef.current = coords;
-  }, [canvasRef, getCoords, state.isDrawing, state.color, state.lineStyle, state.currentPath, state.history, state.historyStep]);
+  }, [canvasRef, getCoords, state.isDrawing, state.color, state.lineStyle, state.currentPath, state.history, state.historyStep, drawingMode]);
 
   const endDrawing = useCallback(() => {
     if (!state.isDrawing || !canvasRef.current) return;
@@ -289,10 +287,7 @@ export const useSimpleDrawing = (canvasRef: React.RefObject<HTMLCanvasElement>) 
     setState(prev => ({ ...prev, lineStyle }));
   }, []);
 
-  const setDrawingMode = useCallback((drawingMode: DrawingMode) => {
-    console.log('🎯 Setting drawing mode to:', drawingMode);
-    setState(prev => ({ ...prev, drawingMode }));
-  }, []);
+
 
   const eraseAtPoint = useCallback((x: number, y: number) => {
     if (!canvasRef.current) return;
@@ -357,7 +352,6 @@ export const useSimpleDrawing = (canvasRef: React.RefObject<HTMLCanvasElement>) 
     isDrawing: state.isDrawing,
     color: state.color,
     lineStyle: state.lineStyle,
-    drawingMode: state.drawingMode,
     canUndo: state.historyStep > 0,
     canRedo: state.historyStep < state.history.length - 1,
     startDrawing,
@@ -367,7 +361,6 @@ export const useSimpleDrawing = (canvasRef: React.RefObject<HTMLCanvasElement>) 
     redo,
     setColor,
     setLineStyle,
-    setDrawingMode,
     eraseAtPoint,
     clearCanvas,
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,7 @@ export interface BoardState {
   mode: Mode;
   arrowStyle: 'solid' | 'dashed';
   trajectoryType: 'pass' | 'movement';
+  drawingMode: DrawingMode;
   gridSnap: boolean;
   zoom: number;
   pan: { x: number; y: number };


### PR DESCRIPTION
Automatically select the "move" mode when any object (tokens, cones, mini-goals, or balls) is placed on the field.

This change centralizes the `drawingMode` state in the global board store and ensures that after adding any item, the user is immediately in "move" mode, streamlining the workflow as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3f42412-10a2-4b3a-a0e9-4bd6423aee21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e3f42412-10a2-4b3a-a0e9-4bd6423aee21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

