### PR TITLE
Lock PWA to portrait orientation

### DIFF
--- a/IPAD_SETUP.md
+++ b/IPAD_SETUP.md
@@ -22,8 +22,8 @@
 ## Configuración Recomendada
 
 ### Orientación
-- **Landscape (horizontal)**: La aplicación está optimizada para uso horizontal
-- Gira tu iPad a modo landscape antes de usar la aplicación
+- **Portrait (vertical)**: La aplicación está optimizada para uso vertical
+- Gira tu iPad a modo portrait antes de usar la aplicación
 
 ### Gestos Táctiles Principales
 - **Arrastrar fichas**: Toca y arrastra cualquier ficha roja o azul
@@ -79,7 +79,7 @@
 ## Tips de Uso
 
 ### Flujo de Trabajo Recomendado
-1. **Orientación**: Coloca el iPad en landscape
+1. **Orientación**: Coloca el iPad en vertical
 2. **Formación base**: Usa el botón "📋 Formaciones" para empezar
 3. **Ajustes**: Arrastra fichas a posiciones específicas
 4. **Movimientos**: Cambia a modo flecha para dibujar movimientos

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -129,7 +129,7 @@ npm run preview
 - ✅ Reset completo
 
 ### 📱 PWA para iPad
-- ✅ Manifest con orientación landscape
+- ✅ Manifest con orientación portrait
 - ✅ Service Worker con precaching
 - ✅ Iconos Apple Touch (192px, 512px)
 - ✅ Meta tags específicos iPad
@@ -188,7 +188,7 @@ npm run preview
 - ✅ Icono en pantalla de inicio
 - ✅ Abre sin barra de Safari
 - ✅ Funciona offline
-- ✅ Orientación landscape automática
+- ✅ Orientación portrait automática
 
 ## 🎉 ¡Proyecto Completado!
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -52,7 +52,7 @@
 - [ ] Funciona offline después de instalación
 - [ ] Icono aparece en pantalla de inicio
 - [ ] Abre en modo standalone (sin barra de Safari)
-- [ ] Orientación landscape por defecto
+- [ ] Orientación vertical (portrait) por defecto
 
 ### ✅ Interacciones Táctiles
 - [ ] Arrastre fluido de fichas con un dedo

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -6,7 +6,7 @@
   "start_url": "/",
   "background_color": "#0b1220",
   "theme_color": "#0b1220",
-  "orientation": "landscape",
+  "orientation": "portrait",
   "scope": "/",
   "icons": [
     {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
         theme_color: '#0b1220',
         background_color: '#0b1220',
         display: 'standalone',
-        orientation: 'landscape',
+        orientation: 'portrait',
         start_url: '/',
         scope: '/',
         icons: [


### PR DESCRIPTION
## Summary
- Restrict PWA to portrait orientation and disable landscape rotation
- Update iPad setup and testing docs to reflect portrait default

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b56f66081083299a99ce08d351e49a