### PR TITLE
Reduce cone token size by 20%

### DIFF
--- a/src/components/Token.tsx
+++ b/src/components/Token.tsx
@@ -22,7 +22,15 @@ export const Token: React.FC<TokenProps> = ({
   
   const isSelected = selectedTokenId === token.id;
   const objectType: ObjectType = token.type || 'player';
-  const radius = objectType === 'player' ? 3 : objectType === 'ball' ? 2 : objectType === 'cone' ? 2 : 3;
+  // Reduce cone size by 20% to make it smaller than before
+  const radius =
+    objectType === 'player'
+      ? 3
+      : objectType === 'ball'
+      ? 2
+      : objectType === 'cone'
+      ? 1.6
+      : 3;
   const hitRadius = 8; // Larger hit area for better touch response on iPad
   
   const handlePointerDown = useCallback((e: React.PointerEvent) => {


### PR DESCRIPTION
## Summary
- shrink cone tokens by 20% for better visual proportion

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b5da858a8483299c977cf785c0ee85