### PR TITLE
Allow choosing object sizes with long press

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { TrajectoriesLayer } from './components/TrajectoriesLayer';
 import { Toolbar } from './components/Toolbar';
 import { PresetsPanel } from './components/PresetsPanel';
 import { FormationsModal } from './components/FormationsModal';
-import { Team, ObjectType } from './types';
+import { Team, ObjectType, TokenSize } from './types';
 import { clampToField, snapToGrid } from './lib/geometry';
 import clsx from 'clsx';
 
@@ -171,7 +171,7 @@ function App() {
   }, [attachWheelListener, attachTouchListeners]);
   
   // Handle adding tokens
-  const handleAddToken = useCallback((team: Team) => {
+  const handleAddToken = useCallback((team: Team, size: TokenSize) => {
     // Add token at center of visible area
     const centerX = showFullField ? fieldWidth / 2 : viewBoxWidth / 2;
     const centerY = fieldHeight / 2;
@@ -184,7 +184,7 @@ function App() {
     
     position = clampToField(position, viewBoxWidth, fieldHeight);
     
-    addToken(team, position.x, position.y);
+    addToken(team, position.x, position.y, 'player', size);
     
     // Automatically switch to move mode after adding a token
     setDrawingMode('move');
@@ -199,7 +199,7 @@ function App() {
   }, [applyFormationByName, setDrawingMode]);
 
   // Handle adding objects
-  const handleAddObject = useCallback((type: ObjectType) => {
+  const handleAddObject = useCallback((type: ObjectType, size: TokenSize) => {
     // Add object at center of visible area
     const centerX = showFullField ? fieldWidth / 2 : viewBoxWidth / 2;
     const centerY = fieldHeight / 2;
@@ -212,7 +212,7 @@ function App() {
     
     position = clampToField(position, viewBoxWidth, fieldHeight);
     
-    addObject(type, position.x, position.y);
+    addObject(type, position.x, position.y, size);
     
     // Automatically switch to move mode after adding an object
     setDrawingMode('move');

--- a/src/components/Token.tsx
+++ b/src/components/Token.tsx
@@ -22,8 +22,10 @@ export const Token: React.FC<TokenProps> = ({
   
   const isSelected = selectedTokenId === token.id;
   const objectType: ObjectType = token.type || 'player';
-  const radius = objectType === 'player' ? 3 : objectType === 'ball' ? 2 : objectType === 'cone' ? 2 : 3;
-  const hitRadius = 8; // Larger hit area for better touch response on iPad
+  const baseRadius = objectType === 'player' ? 3 : objectType === 'ball' ? 2 : objectType === 'cone' ? 2 : 3;
+  const sizeMultiplier = token.size === 'small' ? 0.5 : token.size === 'medium' ? 0.8 : 1;
+  const radius = baseRadius * sizeMultiplier;
+  const hitRadius = 8 * sizeMultiplier; // Adjust hit area based on size
   
   const handlePointerDown = useCallback((e: React.PointerEvent) => {
     e.stopPropagation();
@@ -175,7 +177,7 @@ export const Token: React.FC<TokenProps> = ({
               textAnchor="middle"
               dominantBaseline="central"
               fill="white"
-              fontSize="2.5"
+              fontSize={2.5 * sizeMultiplier}
               fontWeight="bold"
               style={{ pointerEvents: 'none', userSelect: 'none' }}
             >

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { useBoardStore } from '../hooks/useBoardStore';
 import { exportSVGToPNG, downloadJSON } from '../lib/exportPng';
-import { Team, ObjectType, DrawingMode } from '../types';
+import { Team, ObjectType, DrawingMode, TokenSize } from '../types';
 import clsx from 'clsx';
 
 interface ToolbarProps {
   svgRef: React.RefObject<SVGSVGElement>;
-  onAddToken: (team: Team) => void;
-  onAddObject: (type: ObjectType) => void;
+  onAddToken: (team: Team, size: TokenSize) => void;
+  onAddObject: (type: ObjectType, size: TokenSize) => void;
   onShowPresets: () => void;
   onShowFormations: () => void;
   drawColor: string;
@@ -60,6 +60,43 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   
   const redTokens = tokens.filter(t => t.team === 'red');
   const blueTokens = tokens.filter(t => t.team === 'blue');
+
+  const [sizeSettings, setSizeSettings] = useState<Record<string, TokenSize>>({
+    red: 'large',
+    blue: 'large',
+    ball: 'large',
+    cone: 'large',
+    minigoal: 'large'
+  });
+  const [menuTarget, setMenuTarget] = useState<string | null>(null);
+  const longPressTimeout = useRef<number>();
+
+  const startPress = (key: string) => {
+    if (longPressTimeout.current) clearTimeout(longPressTimeout.current);
+    longPressTimeout.current = window.setTimeout(() => {
+      setMenuTarget(key);
+    }, 1000);
+  };
+
+  const cancelPress = () => {
+    if (longPressTimeout.current) {
+      clearTimeout(longPressTimeout.current);
+      longPressTimeout.current = undefined;
+    }
+  };
+
+  const handlePressEnd = (action: () => void) => {
+    if (longPressTimeout.current) {
+      clearTimeout(longPressTimeout.current);
+      longPressTimeout.current = undefined;
+      if (!menuTarget) action();
+    }
+  };
+
+  const handleSizeSelect = (key: string, size: TokenSize) => {
+    setSizeSettings(prev => ({ ...prev, [key]: size }));
+    setMenuTarget(null);
+  };
   
   const handleExportPNG = async () => {
     if (svgRef.current) {
@@ -118,12 +155,16 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   ];
   
   return (
+    <>
     <header className="w-full bg-gray-900 p-2 shadow-lg flex items-center justify-between flex-wrap gap-2">
       {/* Left Section: Title and Team Buttons */}
       <div className="flex items-center gap-2">
         <h1 className="text-xl font-bold text-green-400 hidden sm:block">Pizarra Táctica</h1>
-        <button 
-          onClick={() => onAddToken('red')}
+        <button
+          onPointerDown={() => startPress('red')}
+          onPointerUp={() => handlePressEnd(() => onAddToken('red', sizeSettings.red))}
+          onPointerLeave={cancelPress}
+          onPointerCancel={cancelPress}
           disabled={redTokens.length >= 11}
           className={clsx(
             "w-10 h-10 bg-red-600 rounded-full flex items-center justify-center text-white font-bold text-lg shadow-md hover:bg-red-500 transition-colors",
@@ -133,8 +174,11 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         >
           +
         </button>
-        <button 
-          onClick={() => onAddToken('blue')}
+        <button
+          onPointerDown={() => startPress('blue')}
+          onPointerUp={() => handlePressEnd(() => onAddToken('blue', sizeSettings.blue))}
+          onPointerLeave={cancelPress}
+          onPointerCancel={cancelPress}
           disabled={blueTokens.length >= 11}
           className={clsx(
             "w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center text-white font-bold text-lg shadow-md hover:bg-blue-500 transition-colors",
@@ -145,27 +189,36 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           +
         </button>
       </div>
-      
+
       {/* Center Section: Objects */}
       <div className="flex items-center gap-2 border-l border-r border-gray-700 px-3">
-        <button 
+        <button
           className="control-btn"
           title="Añadir Balón"
-          onClick={() => onAddObject('ball')}
+          onPointerDown={() => startPress('ball')}
+          onPointerUp={() => handlePressEnd(() => onAddObject('ball', sizeSettings.ball))}
+          onPointerLeave={cancelPress}
+          onPointerCancel={cancelPress}
         >
           <BallIcon />
         </button>
-        <button 
+        <button
           className="control-btn"
           title="Añadir Cono"
-          onClick={() => onAddObject('cone')}
+          onPointerDown={() => startPress('cone')}
+          onPointerUp={() => handlePressEnd(() => onAddObject('cone', sizeSettings.cone))}
+          onPointerLeave={cancelPress}
+          onPointerCancel={cancelPress}
         >
           <ConeIcon />
         </button>
-        <button 
+        <button
           className="control-btn"
           title="Añadir Mini Portería"
-          onClick={() => onAddObject('minigoal')}
+          onPointerDown={() => startPress('minigoal')}
+          onPointerUp={() => handlePressEnd(() => onAddObject('minigoal', sizeSettings.minigoal))}
+          onPointerLeave={cancelPress}
+          onPointerCancel={cancelPress}
         >
           <MiniGoalIcon />
         </button>
@@ -291,5 +344,15 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         </button>
       </div>
     </header>
+    {menuTarget && (
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setMenuTarget(null)}>
+        <div className="bg-gray-800 p-4 rounded-lg flex flex-col gap-2" onClick={e => e.stopPropagation()}>
+          <button className="control-btn" onClick={() => handleSizeSelect(menuTarget, 'large')}>Grande</button>
+          <button className="control-btn" onClick={() => handleSizeSelect(menuTarget, 'medium')}>Mediano</button>
+          <button className="control-btn" onClick={() => handleSizeSelect(menuTarget, 'small')}>Pequeño</button>
+        </div>
+      </div>
+    )}
+    </>
   );
 };

--- a/src/hooks/useBoardStore.ts
+++ b/src/hooks/useBoardStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { BoardState, Token, Arrow, Trajectory, Team, Formation, HistoryState, ObjectType } from '../types';
+import { BoardState, Token, Arrow, Trajectory, Team, Formation, HistoryState, ObjectType, TokenSize } from '../types';
 import { loadFromStorage, saveToStorage } from '../lib/localStorage';
 
 interface BoardStore extends BoardState {
@@ -7,8 +7,8 @@ interface BoardStore extends BoardState {
   history: HistoryState;
   
   // Token actions
-  addToken: (team: Team, x: number, y: number, type?: ObjectType) => void;
-  addObject: (type: ObjectType, x: number, y: number) => void;
+  addToken: (team: Team, x: number, y: number, type?: ObjectType, size?: TokenSize) => void;
+  addObject: (type: ObjectType, x: number, y: number, size?: TokenSize) => void;
   updateToken: (id: string, updates: Partial<Token>) => void;
   removeToken: (id: string) => void;
   selectToken: (id: string | null) => void;
@@ -110,7 +110,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
     ...initialState,
     history: initialHistory,
     
-    addToken: (team: Team, x: number, y: number, type: ObjectType = 'player') => {
+    addToken: (team: Team, x: number, y: number, type: ObjectType = 'player', size: TokenSize = 'large') => {
       const state = get();
       
       if (type === 'player') {
@@ -131,6 +131,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
         x,
         y,
         type,
+        size,
       };
       
       const newState = {
@@ -145,7 +146,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
       });
     },
 
-    addObject: (type: ObjectType, x: number, y: number) => {
+    addObject: (type: ObjectType, x: number, y: number, size: TokenSize = 'large') => {
       const state = get();
       
       const newToken: Token = {
@@ -155,6 +156,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
         x,
         y,
         type,
+        size,
       };
       
       const newState = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export type Team = 'red' | 'blue';
 export type ObjectType = 'player' | 'ball' | 'cone' | 'minigoal';
+export type TokenSize = 'large' | 'medium' | 'small';
 
 export interface Token {
   id: string;
@@ -8,6 +9,7 @@ export interface Token {
   x: number;
   y: number;
   type?: ObjectType; // Optional for backward compatibility
+  size?: TokenSize;
 }
 
 export interface Arrow {


### PR DESCRIPTION
## Summary
- Permite seleccionar tamaño grande, mediano o pequeño para fichas, balón, cono y miniportería
- Guarda en el store el tamaño elegido al añadir nuevos objetos
- Muestra el menú de tamaños tras 1 segundo de pulsación prolongada

## Testing
- `npm test` *(falla: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6dd109fe88329a3f89f3ab9f5ffd7