### PR TITLE
feat: add green and yellow team tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Una PWA (Progressive Web App) moderna para entrenadores de fútbol que permite c
 
 - **🎯 Táctil y fluido**: Optimizado para iPad con gestos naturales
 - **⚽ Campo reglamentario**: Proporciones FIFA 105×68m con líneas oficiales
-- **🔴🔵 Fichas de equipos**: Máximo 11 jugadores por equipo (numerados 1-11)
+- **🔴🔵🟢🟡 Fichas de equipos**: Máximo 11 jugadores por equipo (numerados 1-11)
 - **➡️ Flechas tácticas**: Continuas y discontinuas para movimientos y pases
 - **📱 PWA instalable**: Funciona 100% offline en iPad
 - **🎨 Formaciones preset**: 4-3-3, 4-4-2, 3-5-2
@@ -147,7 +147,9 @@ Edita `src/types/index.ts` y `tailwind.config.js`:
 colors: {
   team: {
     red: '#EF4444',    // Rojo del equipo
-    blue: '#3B82F6'    // Azul del equipo
+    blue: '#3B82F6',   // Azul del equipo
+    green: '#22C55E',  // Verde del equipo
+    yellow: '#EAB308'  // Amarillo del equipo
   }
 }
 ```

--- a/src/components/FormationsModal.tsx
+++ b/src/components/FormationsModal.tsx
@@ -7,7 +7,7 @@ interface FormationsModalProps {
   onApplyFormation: (team: Team, formation: string) => void;
 }
 
-const formations = {
+const formations: Record<string, Record<string, number[][]>> = {
   '4-3-3': {
     red: [[10, 50], [25, 20], [25, 40], [25, 60], [25, 80], [45, 30], [45, 50], [45, 70], [65, 25], [65, 50], [65, 75]],
     blue: [[90, 50], [75, 20], [75, 40], [75, 60], [75, 80], [55, 30], [55, 50], [55, 70], [35, 25], [35, 50], [35, 75]]
@@ -29,6 +29,11 @@ const formations = {
     blue: [[90, 50], [75, 10], [75, 30], [75, 50], [75, 70], [75, 90], [55, 30], [55, 50], [55, 70], [35, 40], [35, 60]]
   }
 };
+
+Object.values(formations).forEach(f => {
+  f.green = f.blue;
+  f.yellow = f.blue;
+});
 
 export const FormationsModal: React.FC<FormationsModalProps> = ({
   isOpen,
@@ -52,14 +57,16 @@ export const FormationsModal: React.FC<FormationsModalProps> = ({
         
         <div className="mb-4">
           <label htmlFor="team-select" className="block mb-2">Equipo:</label>
-          <select 
-            id="team-select" 
+          <select
+            id="team-select"
             className="w-full bg-gray-700 rounded p-2"
             value={selectedTeam}
             onChange={(e) => setSelectedTeam(e.target.value as Team)}
           >
             <option value="red">Equipo Rojo</option>
             <option value="blue">Equipo Azul</option>
+            <option value="green">Equipo Verde</option>
+            <option value="yellow">Equipo Amarillo</option>
           </select>
         </div>
         

--- a/src/components/PresetsPanel.tsx
+++ b/src/components/PresetsPanel.tsx
@@ -11,9 +11,11 @@ interface PresetsPanelProps {
 
 export const PresetsPanel: React.FC<PresetsPanelProps> = ({ isOpen, onClose }) => {
   const { applyFormation, tokens } = useBoardStore();
-  
+
   const redTokens = tokens.filter(t => t.team === 'red');
   const blueTokens = tokens.filter(t => t.team === 'blue');
+  const greenTokens = tokens.filter(t => t.team === 'green');
+  const yellowTokens = tokens.filter(t => t.team === 'yellow');
   
   const handleApplyFormation = (formationName: string, team: Team) => {
     const formation = formations.find(f => f.name === formationName);
@@ -43,7 +45,7 @@ export const PresetsPanel: React.FC<PresetsPanelProps> = ({ isOpen, onClose }) =
             <div key={formation.name} className="border border-slate-700 rounded-lg p-4">
               <h3 className="font-semibold mb-3">{formation.name}</h3>
               
-              <div className="flex gap-2 mb-2">
+              <div className="flex gap-2 flex-wrap mb-2">
                 <button
                   className={clsx('btn btn-team-blue text-sm flex-1', {
                     'opacity-50 cursor-not-allowed': blueTokens.length > 0
@@ -62,9 +64,27 @@ export const PresetsPanel: React.FC<PresetsPanelProps> = ({ isOpen, onClose }) =
                 >
                   Aplicar Rojas
                 </button>
+                <button
+                  className={clsx('btn btn-team-green text-sm flex-1', {
+                    'opacity-50 cursor-not-allowed': greenTokens.length > 0
+                  })}
+                  onClick={() => handleApplyFormation(formation.name, 'green')}
+                  disabled={greenTokens.length > 0}
+                >
+                  Aplicar Verdes
+                </button>
+                <button
+                  className={clsx('btn btn-team-yellow text-sm flex-1', {
+                    'opacity-50 cursor-not-allowed': yellowTokens.length > 0
+                  })}
+                  onClick={() => handleApplyFormation(formation.name, 'yellow')}
+                  disabled={yellowTokens.length > 0}
+                >
+                  Aplicar Amarillas
+                </button>
               </div>
-              
-              {(blueTokens.length > 0 || redTokens.length > 0) && (
+
+              {(blueTokens.length > 0 || redTokens.length > 0 || greenTokens.length > 0 || yellowTokens.length > 0) && (
                 <p className="text-xs text-slate-400">
                   Elimina las fichas existentes antes de aplicar una formación
                 </p>
@@ -103,6 +123,7 @@ export const PresetsPanel: React.FC<PresetsPanelProps> = ({ isOpen, onClose }) =
           <h3 className="font-semibold mb-2">Instrucciones</h3>
           <ul className="text-sm text-slate-400 space-y-1">
             <li>• Las formaciones se aplican desde la perspectiva del equipo azul</li>
+            <li>• Los equipos verde y amarillo usan la misma orientación que el azul</li>
             <li>• El equipo rojo se coloca automáticamente en posición espejo</li>
             <li>• Limpia el campo antes de aplicar una nueva formación</li>
           </ul>

--- a/src/components/Token.tsx
+++ b/src/components/Token.tsx
@@ -89,6 +89,8 @@ export const Token: React.FC<TokenProps> = ({
   const teamColors = {
     red: '#EF4444',
     blue: '#3B82F6',
+    green: '#22C55E',
+    yellow: '#EAB308',
   };
   
   const renderObject = () => {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -60,10 +60,14 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   
   const redTokens = tokens.filter(t => t.team === 'red');
   const blueTokens = tokens.filter(t => t.team === 'blue');
+  const greenTokens = tokens.filter(t => t.team === 'green');
+  const yellowTokens = tokens.filter(t => t.team === 'yellow');
 
   const [sizeSettings, setSizeSettings] = useState<Record<string, TokenSize>>({
     red: 'large',
     blue: 'large',
+    green: 'large',
+    yellow: 'large',
     ball: 'large',
     cone: 'large',
     minigoal: 'large'
@@ -148,9 +152,10 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 
   const colorOptions = [
     { color: 'white', className: 'bg-white border-2 border-gray-400' },
-    { color: '#FBBF24', className: 'bg-yellow-400' },
     { color: '#EF4444', className: 'bg-red-500' },
     { color: '#3B82F6', className: 'bg-blue-500' },
+    { color: '#22C55E', className: 'bg-green-500' },
+    { color: '#EAB308', className: 'bg-yellow-500' },
     { color: 'transparent', className: 'bg-gray-800 border-2 border-gray-500', title: 'Borrador' },
   ];
   
@@ -185,6 +190,34 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             { 'opacity-50 cursor-not-allowed': blueTokens.length >= 11 }
           )}
           title={`Azules: ${blueTokens.length}/11`}
+        >
+          +
+        </button>
+        <button
+          onPointerDown={() => startPress('green')}
+          onPointerUp={() => handlePressEnd(() => onAddToken('green', sizeSettings.green))}
+          onPointerLeave={cancelPress}
+          onPointerCancel={cancelPress}
+          disabled={greenTokens.length >= 11}
+          className={clsx(
+            "w-10 h-10 bg-green-600 rounded-full flex items-center justify-center text-white font-bold text-lg shadow-md hover:bg-green-500 transition-colors",
+            { 'opacity-50 cursor-not-allowed': greenTokens.length >= 11 }
+          )}
+          title={`Verdes: ${greenTokens.length}/11`}
+        >
+          +
+        </button>
+        <button
+          onPointerDown={() => startPress('yellow')}
+          onPointerUp={() => handlePressEnd(() => onAddToken('yellow', sizeSettings.yellow))}
+          onPointerLeave={cancelPress}
+          onPointerCancel={cancelPress}
+          disabled={yellowTokens.length >= 11}
+          className={clsx(
+            "w-10 h-10 bg-yellow-500 rounded-full flex items-center justify-center text-white font-bold text-lg shadow-md hover:bg-yellow-400 transition-colors",
+            { 'opacity-50 cursor-not-allowed': yellowTokens.length >= 11 }
+          )}
+          title={`Amarillas: ${yellowTokens.length}/11`}
         >
           +
         </button>

--- a/src/hooks/useBoardStore.ts
+++ b/src/hooks/useBoardStore.ts
@@ -413,7 +413,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
 
     applyFormationByName: (formationName: string, team: Team) => {
       // Formation positions from FormationsModal
-      const formations = {
+      const formations: Record<string, Record<string, number[][]>> = {
         '4-3-3': {
           red: [[10, 50], [25, 20], [25, 40], [25, 60], [25, 80], [45, 30], [45, 50], [45, 70], [65, 25], [65, 50], [65, 75]],
           blue: [[90, 50], [75, 20], [75, 40], [75, 60], [75, 80], [55, 30], [55, 50], [55, 70], [35, 25], [35, 50], [35, 75]]
@@ -435,6 +435,11 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
           blue: [[90, 50], [75, 10], [75, 30], [75, 50], [75, 70], [75, 90], [55, 30], [55, 50], [55, 70], [35, 40], [35, 60]]
         }
       };
+
+      Object.values(formations).forEach(f => {
+        f.green = f.blue;
+        f.yellow = f.blue;
+      });
 
       const state = get();
       const fieldWidth = 105;

--- a/src/lib/formations.ts
+++ b/src/lib/formations.ts
@@ -1,4 +1,4 @@
-import { Formation } from '../types';
+import { Formation, Team } from '../types';
 
 // Formations are positioned for a 105x68 field
 // Positions are in meters from bottom-left corner
@@ -75,19 +75,19 @@ export const formations: Formation[] = [
 ];
 
 // Mirror formation for red team (attacking from right to left)
-export const getFormationForTeam = (formation: Formation, team: 'red' | 'blue'): Formation => {
-  if (team === 'blue') {
-    return formation;
+export const getFormationForTeam = (formation: Formation, team: Team): Formation => {
+  if (team === 'red') {
+    const fieldWidth = 105;
+    return {
+      ...formation,
+      tokens: formation.tokens.map(token => ({
+        ...token,
+        team: 'red',
+        x: fieldWidth - token.x,
+      })),
+    };
   }
-  
-  // Mirror for red team
-  const fieldWidth = 105;
-  return {
-    ...formation,
-    tokens: formation.tokens.map(token => ({
-      ...token,
-      team: 'red',
-      x: fieldWidth - token.x,
-    })),
-  };
+
+  // For blue, green, and yellow teams, use formation as is
+  return formation;
 };

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -275,6 +275,14 @@
   .btn-team-blue {
     @apply bg-team-blue hover:bg-blue-600 text-white;
   }
+
+  .btn-team-green {
+    @apply bg-team-green hover:bg-green-600 text-white;
+  }
+
+  .btn-team-yellow {
+    @apply bg-team-yellow hover:bg-yellow-600 text-white;
+  }
   
   .btn-active {
     @apply ring-2 ring-blue-400 bg-blue-700;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type Team = 'red' | 'blue';
+export type Team = 'red' | 'blue' | 'green' | 'yellow';
 export type ObjectType = 'player' | 'ball' | 'cone' | 'minigoal';
 export type TokenSize = 'large' | 'medium' | 'small';
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,7 +14,9 @@ export default {
         },
         team: {
           red: '#EF4444',
-          blue: '#3B82F6'
+          blue: '#3B82F6',
+          green: '#22C55E',
+          yellow: '#EAB308'
         }
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- add green and yellow team colors
- allow presets and formations for four teams
- document new token options

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b807c603208329b0de37718e4f7791