### PR TITLE
Respect token size when applying formations

### DIFF
--- a/src/components/PresetsPanel.tsx
+++ b/src/components/PresetsPanel.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { useBoardStore } from '../hooks/useBoardStore';
 import { formations, getFormationForTeam } from '../lib/formations';
-import { Team } from '../types';
+import { Team, Formation } from '../types';
 import clsx from 'clsx';
 
 interface PresetsPanelProps {
   isOpen: boolean;
   onClose: () => void;
+  onApplyFormation: (formation: Formation, team: Team) => void;
 }
 
-export const PresetsPanel: React.FC<PresetsPanelProps> = ({ isOpen, onClose }) => {
-  const { applyFormation, tokens } = useBoardStore();
+export const PresetsPanel: React.FC<PresetsPanelProps> = ({ isOpen, onClose, onApplyFormation }) => {
+  const { tokens } = useBoardStore();
 
   const redTokens = tokens.filter(t => t.team === 'red');
   const blueTokens = tokens.filter(t => t.team === 'blue');
@@ -21,7 +22,7 @@ export const PresetsPanel: React.FC<PresetsPanelProps> = ({ isOpen, onClose }) =
     const formation = formations.find(f => f.name === formationName);
     if (formation) {
       const teamFormation = getFormationForTeam(formation, team);
-      applyFormation(teamFormation, team);
+      onApplyFormation(teamFormation, team);
     }
   };
   

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -19,6 +19,8 @@ interface ToolbarProps {
   onUndoDraw: () => void;
   onRedoDraw: () => void;
   onClearCanvas: () => void;
+  sizeSettings: Record<Team | 'ball' | 'cone' | 'minigoal', TokenSize>;
+  onSizeChange: (key: Team | 'ball' | 'cone' | 'minigoal', size: TokenSize) => void;
 }
 
 export const Toolbar: React.FC<ToolbarProps> = ({ 
@@ -37,7 +39,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   onSetDrawingMode,
   onUndoDraw,
   onRedoDraw,
-  onClearCanvas
+  onClearCanvas,
+  sizeSettings,
+  onSizeChange
 }) => {
   
   const {
@@ -63,19 +67,10 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   const greenTokens = tokens.filter(t => t.team === 'green');
   const yellowTokens = tokens.filter(t => t.team === 'yellow');
 
-  const [sizeSettings, setSizeSettings] = useState<Record<string, TokenSize>>({
-    red: 'large',
-    blue: 'large',
-    green: 'large',
-    yellow: 'large',
-    ball: 'large',
-    cone: 'large',
-    minigoal: 'large'
-  });
-  const [menuTarget, setMenuTarget] = useState<string | null>(null);
+  const [menuTarget, setMenuTarget] = useState<(Team | 'ball' | 'cone' | 'minigoal') | null>(null);
   const longPressTimeout = useRef<number>();
 
-  const startPress = (key: string) => {
+  const startPress = (key: Team | 'ball' | 'cone' | 'minigoal') => {
     if (longPressTimeout.current) clearTimeout(longPressTimeout.current);
     longPressTimeout.current = window.setTimeout(() => {
       setMenuTarget(key);
@@ -97,8 +92,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     }
   };
 
-  const handleSizeSelect = (key: string, size: TokenSize) => {
-    setSizeSettings(prev => ({ ...prev, [key]: size }));
+  const handleSizeSelect = (key: Team | 'ball' | 'cone' | 'minigoal', size: TokenSize) => {
+    onSizeChange(key, size);
     setMenuTarget(null);
   };
   

--- a/src/hooks/useBoardStore.ts
+++ b/src/hooks/useBoardStore.ts
@@ -39,8 +39,8 @@ interface BoardStore extends BoardState {
   // Utility actions
   reset: () => void;
   mirror: () => void;
-  applyFormation: (formation: Formation, team: Team) => void;
-  applyFormationByName: (formationName: string, team: Team) => void;
+  applyFormation: (formation: Formation, team: Team, size?: TokenSize) => void;
+  applyFormationByName: (formationName: string, team: Team, size?: TokenSize) => void;
   
   // History actions
   undo: () => void;
@@ -390,13 +390,14 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
       });
     },
     
-    applyFormation: (formation: Formation, team: Team) => {
+    applyFormation: (formation: Formation, team: Team, size: TokenSize = 'large') => {
       const state = get();
       const otherTeamTokens = state.tokens.filter(t => t.team !== team);
       const formationTokens = formation.tokens.map(token => ({
         ...token,
         id: generateId(),
         team,
+        size,
       }));
       
       const newState = {
@@ -411,7 +412,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
       });
     },
 
-    applyFormationByName: (formationName: string, team: Team) => {
+    applyFormationByName: (formationName: string, team: Team, size: TokenSize = 'large') => {
       // Formation positions from FormationsModal
       const formations: Record<string, Record<string, number[][]>> = {
         '4-3-3': {
@@ -459,7 +460,8 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
         number: index + 1,
         x: (pos[0] / 100) * fieldWidth, // Convert percentage to field coordinates
         y: (pos[1] / 100) * fieldHeight,
-        type: 'player'
+        type: 'player',
+        size,
       }));
       
       const newState = {


### PR DESCRIPTION
## Summary
- Track selected token size for each team in `App` and share it with the toolbar
- Add size support to formation application so new tokens honor current size settings
- Route preset formation panel through parent callback to apply sizes consistently

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b81ba49d1483299a4072fc44dcc542