### PR TITLE
feat: support area selection and group token movement

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,6 +94,7 @@ function App() {
     // isDragging, // Not used with new canvas drawing
     isDrawingTrajectory,
     trajectoryPreview,
+    selectionRect,
   } = usePointerInteractions(svgRef, viewBoxWidth, fieldHeight);
 
   // Canvas drawing
@@ -381,7 +382,21 @@ function App() {
                   style={{ pointerEvents: 'none' }}
                 />
               )}
-              
+
+              {selectionRect && (
+                <rect
+                  x={selectionRect.x}
+                  y={selectionRect.y}
+                  width={selectionRect.width}
+                  height={selectionRect.height}
+                  fill="rgba(251,191,36,0.1)"
+                  stroke="#FBBF24"
+                  strokeWidth={0.5}
+                  strokeDasharray="4"
+                  style={{ pointerEvents: 'none' }}
+                />
+              )}
+
               {/* Tokens */}
               {tokens.map((token) => (
                 <Token

--- a/src/components/Token.tsx
+++ b/src/components/Token.tsx
@@ -16,12 +16,12 @@ export const Token: React.FC<TokenProps> = ({
   onPointerDown,
   onEditNumber
 }) => {
-  const { selectedTokenId, selectToken, removeToken } = useBoardStore();
+  const { selectedTokenIds, selectToken, removeToken } = useBoardStore();
   const lastTapRef = useRef<number>(0);
   const tapCountRef = useRef<number>(0);
   const tapTimeoutRef = useRef<number | null>(null);
-  
-  const isSelected = selectedTokenId === token.id;
+
+  const isSelected = selectedTokenIds.includes(token.id);
   const objectType: ObjectType = token.type || 'player';
   const baseRadius = objectType === 'player' ? 3 : objectType === 'ball' ? 2 : objectType === 'cone' ? 2 : 3;
   const sizeMultiplier = token.size === 'small' ? 0.5 : token.size === 'medium' ? 0.8 : 1;
@@ -67,7 +67,9 @@ export const Token: React.FC<TokenProps> = ({
         tapCountRef.current = 0;
       }, 300);
     } else {
-      selectToken(token.id);
+      if (!selectedTokenIds.includes(token.id)) {
+        selectToken(token.id);
+      }
       onPointerDown(e, token);
 
       tapTimeoutRef.current = window.setTimeout(() => {
@@ -76,7 +78,7 @@ export const Token: React.FC<TokenProps> = ({
       }, 300);
     }
 
-  }, [token, onPointerDown, onEditNumber, selectToken, removeToken]);
+  }, [token, onPointerDown, onEditNumber, selectToken, removeToken, selectedTokenIds]);
   
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();

--- a/src/hooks/useBoardStore.ts
+++ b/src/hooks/useBoardStore.ts
@@ -12,6 +12,7 @@ interface BoardStore extends BoardState {
   updateToken: (id: string, updates: Partial<Token>) => void;
   removeToken: (id: string) => void;
   selectToken: (id: string | null) => void;
+  selectTokens: (ids: string[]) => void;
   
   // Arrow actions
   addArrow: (from: { x: number; y: number }, to: { x: number; y: number }) => void;
@@ -66,7 +67,7 @@ const initialState: BoardState = {
   zoom: 1,
   pan: { x: 0, y: 0 },
   showFullField: true,
-  selectedTokenId: null,
+  selectedTokenIds: [],
   selectedArrowId: null,
   selectedTrajectoryId: null,
 };
@@ -137,7 +138,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
       const newState = {
         ...state,
         tokens: [...state.tokens, newToken],
-        selectedTokenId: newToken.id,
+        selectedTokenIds: [newToken.id],
       };
       
       set({
@@ -162,7 +163,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
       const newState = {
         ...state,
         tokens: [...state.tokens, newToken],
-        selectedTokenId: newToken.id,
+        selectedTokenIds: [newToken.id],
       };
       
       set({
@@ -193,7 +194,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
       const newState = {
         ...state,
         tokens: state.tokens.filter(t => t.id !== id),
-        selectedTokenId: state.selectedTokenId === id ? null : state.selectedTokenId,
+        selectedTokenIds: state.selectedTokenIds.filter(tid => tid !== id),
       };
       
       set({
@@ -203,7 +204,10 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
     },
     
     selectToken: (id: string | null) => {
-      set({ selectedTokenId: id, selectedArrowId: null, selectedTrajectoryId: null });
+      set({ selectedTokenIds: id ? [id] : [], selectedArrowId: null, selectedTrajectoryId: null });
+    },
+    selectTokens: (ids: string[]) => {
+      set({ selectedTokenIds: ids, selectedArrowId: null, selectedTrajectoryId: null });
     },
     
     addArrow: (from: { x: number; y: number }, to: { x: number; y: number }) => {
@@ -260,11 +264,11 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
     },
     
     selectArrow: (id: string | null) => {
-      set({ selectedArrowId: id, selectedTokenId: null, selectedTrajectoryId: null });
+      set({ selectedArrowId: id, selectedTokenIds: [], selectedTrajectoryId: null });
     },
     
     setMode: (mode: BoardState['mode']) => {
-      set({ mode, selectedTokenId: null, selectedArrowId: null, selectedTrajectoryId: null });
+      set({ mode, selectedTokenIds: [], selectedArrowId: null, selectedTrajectoryId: null });
     },
     
     setArrowStyle: (arrowStyle: 'solid' | 'dashed') => {
@@ -324,7 +328,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
     },
     
     selectTrajectory: (id: string | null) => {
-      set({ selectedTrajectoryId: id, selectedTokenId: null, selectedArrowId: null });
+      set({ selectedTrajectoryId: id, selectedTokenIds: [], selectedArrowId: null });
     },
     
     setTrajectoryType: (trajectoryType: 'pass' | 'movement') => {
@@ -403,7 +407,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
       const newState = {
         ...state,
         tokens: [...otherTeamTokens, ...formationTokens],
-        selectedTokenId: null,
+        selectedTokenIds: [],
       };
       
       set({
@@ -467,7 +471,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
       const newState = {
         ...state,
         tokens: [...otherTokens, ...formationTokens],
-        selectedTokenId: null,
+        selectedTokenIds: [],
       };
       
       set({
@@ -531,7 +535,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
         zoom: state.zoom,
         pan: state.pan,
         showFullField: state.showFullField,
-        selectedTokenId: null, // Don't persist selection
+        selectedTokenIds: [], // Don't persist selection
         selectedArrowId: null,
         selectedTrajectoryId: null,
       });
@@ -543,7 +547,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
         const newState = {
           ...initialState,
           ...savedState,
-          selectedTokenId: null,
+          selectedTokenIds: [],
           selectedArrowId: null,
           selectedTrajectoryId: null,
         };
@@ -577,7 +581,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
             tokens: parsed.tokens,
             arrows: parsed.arrows,
             trajectories: parsed.trajectories || [],
-            selectedTokenId: null,
+            selectedTokenIds: [],
             selectedArrowId: null,
             selectedTrajectoryId: null,
           };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,7 +35,7 @@ export interface BoardState {
   zoom: number;
   pan: { x: number; y: number };
   showFullField: boolean;
-  selectedTokenId: string | null;
+  selectedTokenIds: string[];
   selectedArrowId: string | null;
   selectedTrajectoryId: string | null;
 }


### PR DESCRIPTION
## Summary
- allow selecting multiple tokens by drawing a rectangle
- move all selected tokens together when dragging one

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b841f01da08329a4a1ecd8db3da0fe