### PR TITLE
Add recording and playback for token movements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,10 @@ function App() {
     updateTrajectory,
     updateToken,
     load,
+    recording,
+    setRecording,
+    playTokenPaths,
+    clearTokenPaths,
   } = useBoardStore();
   
   // Field dimensions
@@ -254,10 +258,19 @@ function App() {
     position = clampToField(position, viewBoxWidth, fieldHeight);
     
     addObject(type, position.x, position.y, size);
-    
+
     // Automatically switch to move mode after adding an object
     setDrawingMode('move');
   }, [addObject, showFullField, fieldWidth, fieldHeight, viewBoxWidth, gridSnap, setDrawingMode]);
+
+  const handleToggleRecording = useCallback(() => {
+    setRecording(!recording);
+    clearTokenPaths();
+  }, [recording, setRecording, clearTokenPaths]);
+
+  const handlePlayRecording = useCallback(() => {
+    playTokenPaths();
+  }, [playTokenPaths]);
 
   // Handle canvas pointer down - no double tap for lines
   const handleCanvasPointerDown = useCallback((e: any) => {
@@ -301,6 +314,9 @@ function App() {
         onClearCanvas={clearCanvas}
         sizeSettings={sizeSettings}
         onSizeChange={(key, size) => setSizeSettings(prev => ({ ...prev, [key]: size }))}
+        isRecording={recording}
+        onToggleRecording={handleToggleRecording}
+        onPlayRecording={handlePlayRecording}
         />
       </div>
       

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -21,6 +21,9 @@ interface ToolbarProps {
   onClearCanvas: () => void;
   sizeSettings: Record<Team | 'ball' | 'cone' | 'minigoal', TokenSize>;
   onSizeChange: (key: Team | 'ball' | 'cone' | 'minigoal', size: TokenSize) => void;
+  isRecording: boolean;
+  onToggleRecording: () => void;
+  onPlayRecording: () => void;
 }
 
 export const Toolbar: React.FC<ToolbarProps> = ({ 
@@ -41,7 +44,10 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   onRedoDraw,
   onClearCanvas,
   sizeSettings,
-  onSizeChange
+  onSizeChange,
+  isRecording,
+  onToggleRecording,
+  onPlayRecording,
 }) => {
   
   const {
@@ -140,6 +146,18 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     <svg viewBox="0 0 100 100" className="w-7 h-7">
       <rect x="5" y="20" width="90" height="70" stroke="white" strokeWidth="6" fill="none"/>
       <line x1="5" y1="90" x2="95" y2="90" stroke="white" strokeWidth="6"/>
+    </svg>
+  );
+
+  const RecordIcon = () => (
+    <svg viewBox="0 0 24 24" className="w-5 h-5">
+      <circle cx="12" cy="12" r="8" fill="red" />
+    </svg>
+  );
+
+  const PlayIcon = () => (
+    <svg viewBox="0 0 24 24" className="w-5 h-5">
+      <polygon points="8,5 19,12 8,19" fill="white" />
     </svg>
   );
 
@@ -294,7 +312,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           ))}
         </div>
       </div>
-      
+
       {/* Undo/Redo */}
       <div className="flex items-center gap-2 border-l border-r border-gray-700 px-3">
         <button 
@@ -316,7 +334,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           Rehacer
         </button>
       </div>
-      
+
       {/* Right Section: Actions */}
       <div className="flex items-center gap-2">
         <button 
@@ -355,7 +373,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             }}
           />
         </label>
-        <button 
+        <button
           className="control-btn"
           onClick={handleExportPNG}
         >
@@ -369,6 +387,23 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           }}
         >
           Limpiar
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2 border-l border-r border-gray-700 px-3">
+        <button
+          className={clsx('control-btn', { 'bg-red-700': isRecording })}
+          onClick={onToggleRecording}
+          title="Grabar"
+        >
+          <RecordIcon />
+        </button>
+        <button
+          className="control-btn"
+          onClick={onPlayRecording}
+          title="Play"
+        >
+          <PlayIcon />
         </button>
       </div>
     </header>

--- a/src/hooks/usePointerInteractions.ts
+++ b/src/hooks/usePointerInteractions.ts
@@ -35,6 +35,8 @@ export const usePointerInteractions = (
     selectTokens,
     selectArrow,
     selectTrajectory,
+    recording,
+    setTokenPath,
   } = useBoardStore();
   
   const [dragState, setDragState] = useState<DragState>({
@@ -99,6 +101,7 @@ export const usePointerInteractions = (
     const svgPoint = getSVGPoint(e.clientX, e.clientY);
 
     if (mode === 'trajectory') {
+      const currentSelected = recording ? useBoardStore.getState().selectedTokenIds : [];
       // Start trajectory drawing
       setDragState({
         isDragging: false,
@@ -109,11 +112,11 @@ export const usePointerInteractions = (
         isDrawingTrajectory: true,
         selectionStart: null,
         selectionRect: null,
-        selectedTokenIds: [],
+        selectedTokenIds: currentSelected,
         initialPositions: {},
       });
       selectArrow(null);
-      selectToken(null);
+      if (!recording) selectToken(null);
       selectTrajectory(null);
     } else {
       // Start selection box
@@ -133,7 +136,7 @@ export const usePointerInteractions = (
       selectArrow(null);
       selectTrajectory(null);
     }
-  }, [mode, getSVGPoint, selectToken, selectTokens, selectArrow, selectTrajectory]);
+  }, [mode, getSVGPoint, recording, selectToken, selectTokens, selectArrow, selectTrajectory]);
   
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
     // Handle selection box drawing
@@ -210,6 +213,9 @@ export const usePointerInteractions = (
         
         // Create trajectory
         addTrajectory(finalPoints, trajectoryType);
+        if (recording && dragState.selectedTokenIds.length > 0 && trajectoryType === 'movement') {
+          dragState.selectedTokenIds.forEach(id => setTokenPath(id, finalPoints));
+        }
       }
       
       setDragState({
@@ -270,7 +276,7 @@ export const usePointerInteractions = (
       // Release pointer capture
       (e.target as Element).releasePointerCapture(e.pointerId);
     }
-  }, [mode, dragState, getSVGPoint, gridSnap, fieldWidth, fieldHeight, addArrow, addTrajectory, trajectoryType, selectTokens]);
+  }, [mode, dragState, getSVGPoint, gridSnap, fieldWidth, fieldHeight, addArrow, addTrajectory, trajectoryType, selectTokens, recording, setTokenPath]);
   
   const handlePointerCancel = useCallback((_e: React.PointerEvent) => {
     setDragState({


### PR DESCRIPTION
## Summary
- add record and play buttons in toolbar to capture token movement paths
- extend board store with recording state and token path playback
- allow pointer interactions to store and animate selected token trajectories

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b86836cae88329b2cb2ac6de93bdec