### PR TITLE
Add recording and playback for token movements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,10 @@ function App() {
     updateTrajectory,
     updateToken,
     load,
+    recording,
+    startRecording,
+    stopRecording,
+    playTokenPaths,
   } = useBoardStore();
   
   // Field dimensions
@@ -254,10 +258,22 @@ function App() {
     position = clampToField(position, viewBoxWidth, fieldHeight);
     
     addObject(type, position.x, position.y, size);
-    
+
     // Automatically switch to move mode after adding an object
     setDrawingMode('move');
   }, [addObject, showFullField, fieldWidth, fieldHeight, viewBoxWidth, gridSnap, setDrawingMode]);
+
+  const handleToggleRecording = useCallback(() => {
+    if (recording) {
+      stopRecording();
+    } else {
+      startRecording();
+    }
+  }, [recording, startRecording, stopRecording]);
+
+  const handlePlayRecording = useCallback(() => {
+    playTokenPaths();
+  }, [playTokenPaths]);
 
   // Handle canvas pointer down - no double tap for lines
   const handleCanvasPointerDown = useCallback((e: any) => {
@@ -301,6 +317,9 @@ function App() {
         onClearCanvas={clearCanvas}
         sizeSettings={sizeSettings}
         onSizeChange={(key, size) => setSizeSettings(prev => ({ ...prev, [key]: size }))}
+        isRecording={recording}
+        onToggleRecording={handleToggleRecording}
+        onPlayRecording={handlePlayRecording}
         />
       </div>
       

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -21,6 +21,9 @@ interface ToolbarProps {
   onClearCanvas: () => void;
   sizeSettings: Record<Team | 'ball' | 'cone' | 'minigoal', TokenSize>;
   onSizeChange: (key: Team | 'ball' | 'cone' | 'minigoal', size: TokenSize) => void;
+  isRecording: boolean;
+  onToggleRecording: () => void;
+  onPlayRecording: () => void;
 }
 
 export const Toolbar: React.FC<ToolbarProps> = ({ 
@@ -41,7 +44,10 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   onRedoDraw,
   onClearCanvas,
   sizeSettings,
-  onSizeChange
+  onSizeChange,
+  isRecording,
+  onToggleRecording,
+  onPlayRecording,
 }) => {
   
   const {
@@ -140,6 +146,18 @@ export const Toolbar: React.FC<ToolbarProps> = ({
     <svg viewBox="0 0 100 100" className="w-7 h-7">
       <rect x="5" y="20" width="90" height="70" stroke="white" strokeWidth="6" fill="none"/>
       <line x1="5" y1="90" x2="95" y2="90" stroke="white" strokeWidth="6"/>
+    </svg>
+  );
+
+  const RecordIcon = () => (
+    <svg viewBox="0 0 24 24" className="w-5 h-5">
+      <circle cx="12" cy="12" r="8" fill="red" />
+    </svg>
+  );
+
+  const PlayIcon = () => (
+    <svg viewBox="0 0 24 24" className="w-5 h-5">
+      <polygon points="8,5 19,12 8,19" fill="white" />
     </svg>
   );
 
@@ -294,7 +312,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           ))}
         </div>
       </div>
-      
+
       {/* Undo/Redo */}
       <div className="flex items-center gap-2 border-l border-r border-gray-700 px-3">
         <button 
@@ -316,7 +334,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           Rehacer
         </button>
       </div>
-      
+
       {/* Right Section: Actions */}
       <div className="flex items-center gap-2">
         <button 
@@ -355,7 +373,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
             }}
           />
         </label>
-        <button 
+        <button
           className="control-btn"
           onClick={handleExportPNG}
         >
@@ -369,6 +387,23 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           }}
         >
           Limpiar
+        </button>
+      </div>
+
+      <div className="flex items-center gap-2 border-l border-r border-gray-700 px-3">
+        <button
+          className={clsx('control-btn', { 'bg-red-700': isRecording })}
+          onClick={onToggleRecording}
+          title="Grabar"
+        >
+          <RecordIcon />
+        </button>
+        <button
+          className="control-btn"
+          onClick={onPlayRecording}
+          title="Play"
+        >
+          <PlayIcon />
         </button>
       </div>
     </header>

--- a/src/hooks/useBoardStore.ts
+++ b/src/hooks/useBoardStore.ts
@@ -1,10 +1,13 @@
 import { create } from 'zustand';
-import { BoardState, Token, Arrow, Trajectory, Team, Formation, HistoryState, ObjectType, TokenSize } from '../types';
+import { BoardState, Token, Arrow, Trajectory, Team, Formation, HistoryState, ObjectType, TokenSize, Point } from '../types';
 import { loadFromStorage, saveToStorage } from '../lib/localStorage';
 
 interface BoardStore extends BoardState {
   // History
   history: HistoryState;
+  recording: boolean;
+  tokenPaths: Record<string, Point[]>;
+  recordingStartPositions: Record<string, Point>;
   
   // Token actions
   addToken: (team: Team, x: number, y: number, type?: ObjectType, size?: TokenSize) => void;
@@ -54,6 +57,11 @@ interface BoardStore extends BoardState {
   load: () => void;
   exportState: () => string;
   importState: (data: string) => void;
+  startRecording: () => void;
+  stopRecording: () => void;
+  addTokenPathPoint: (id: string, point: Point) => void;
+  clearTokenPaths: () => void;
+  playTokenPaths: () => void;
 }
 
 const initialState: BoardState = {
@@ -109,7 +117,10 @@ const addToHistory = (currentState: BoardState, history: HistoryState): HistoryS
 
 export const useBoardStore = create<BoardStore>((set, get) => ({
     ...initialState,
-    history: initialHistory,
+  history: initialHistory,
+  recording: false,
+  tokenPaths: {},
+  recordingStartPositions: {},
     
     addToken: (team: Team, x: number, y: number, type: ObjectType = 'player', size: TokenSize = 'large') => {
       const state = get();
@@ -359,10 +370,12 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
         showFullField: get().showFullField,
         gridSnap: get().gridSnap,
       };
-      
+
       set({
         ...newState,
         history: addToHistory(newState, get().history),
+        tokenPaths: {},
+        recording: false,
       });
     },
     
@@ -558,6 +571,8 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
             states: [newState],
             currentIndex: 0,
           },
+          tokenPaths: {},
+          recording: false,
         });
       }
     },
@@ -585,15 +600,67 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
             selectedArrowId: null,
             selectedTrajectoryId: null,
           };
-          
+
           set({
             ...newState,
             history: addToHistory(newState, get().history),
+            tokenPaths: {},
+            recording: false,
           });
         }
       } catch (error) {
         console.error('Error importing state:', error);
       }
+    },
+
+    startRecording: () => {
+      const startPositions: Record<string, Point> = {};
+      get().tokens.forEach(t => {
+        startPositions[t.id] = { x: t.x, y: t.y };
+      });
+      set({ recording: true, recordingStartPositions: startPositions, tokenPaths: {} });
+    },
+
+    stopRecording: () => {
+      const start = get().recordingStartPositions;
+      set(state => ({
+        recording: false,
+        tokens: state.tokens.map(t => start[t.id] ? { ...t, x: start[t.id].x, y: start[t.id].y } : t),
+        selectedTokenIds: [],
+      }));
+    },
+
+    addTokenPathPoint: (id: string, point: Point) => {
+      set(state => {
+        const path = state.tokenPaths[id] || [];
+        return { tokenPaths: { ...state.tokenPaths, [id]: [...path, point] } };
+      });
+    },
+
+    clearTokenPaths: () => {
+      set({ tokenPaths: {} });
+    },
+
+    playTokenPaths: () => {
+      const paths = get().tokenPaths;
+      const maxSteps = Math.max(0, ...Object.values(paths).map(p => p.length));
+      let step = 0;
+      set({ selectedTokenIds: [] });
+      const animate = () => {
+        if (step >= maxSteps) return;
+        const updates: Record<string, Point> = {};
+        Object.entries(paths).forEach(([id, path]) => {
+          const point = path[Math.min(step, path.length - 1)];
+          updates[id] = point;
+        });
+        set(state => ({
+          ...state,
+          tokens: state.tokens.map(t => updates[t.id] ? { ...t, x: updates[t.id].x, y: updates[t.id].y } : t)
+        }));
+        step++;
+        requestAnimationFrame(animate);
+      };
+      animate();
     },
   }));
 


### PR DESCRIPTION
## Summary
- allow record button to directly start and stop movement capture
- replace setRecording toggle with explicit start/stop actions that store starting positions and reset tokens on stop
- clear selected tokens on recording stop and playback to hide selection during animation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b86836cae88329b2cb2ac6de93bdec