### PR TITLE
Use medium size as default for tokens and objects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,13 +24,13 @@ function App() {
   const [showFormations, setShowFormations] = useState(false);
   const [editingToken, setEditingToken] = useState<TokenType | null>(null);
   const [sizeSettings, setSizeSettings] = useState<Record<Team | 'ball' | 'cone' | 'minigoal', TokenSize>>({
-    red: 'large',
-    blue: 'large',
-    green: 'large',
-    yellow: 'large',
-    ball: 'large',
-    cone: 'large',
-    minigoal: 'large',
+    red: 'medium',
+    blue: 'medium',
+    green: 'medium',
+    yellow: 'medium',
+    ball: 'medium',
+    cone: 'medium',
+    minigoal: 'medium',
   });
   // Removed canvas tap refs as double tap is not used for lines anymore
   

--- a/src/hooks/useBoardStore.ts
+++ b/src/hooks/useBoardStore.ts
@@ -122,7 +122,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
   tokenPaths: {},
   recordingStartPositions: {},
     
-    addToken: (team: Team, x: number, y: number, type: ObjectType = 'player', size: TokenSize = 'large') => {
+    addToken: (team: Team, x: number, y: number, type: ObjectType = 'player', size: TokenSize = 'medium') => {
       const state = get();
       
       if (type === 'player') {
@@ -158,7 +158,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
       });
     },
 
-    addObject: (type: ObjectType, x: number, y: number, size: TokenSize = 'large') => {
+    addObject: (type: ObjectType, x: number, y: number, size: TokenSize = 'medium') => {
       const state = get();
       
       const newToken: Token = {
@@ -407,7 +407,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
       });
     },
     
-    applyFormation: (formation: Formation, team: Team, size: TokenSize = 'large') => {
+    applyFormation: (formation: Formation, team: Team, size: TokenSize = 'medium') => {
       const state = get();
       const otherTeamTokens = state.tokens.filter(t => t.team !== team);
       const formationTokens = formation.tokens.map(token => ({
@@ -429,7 +429,7 @@ export const useBoardStore = create<BoardStore>((set, get) => ({
       });
     },
 
-    applyFormationByName: (formationName: string, team: Team, size: TokenSize = 'large') => {
+    applyFormationByName: (formationName: string, team: Team, size: TokenSize = 'medium') => {
       // Formation positions from FormationsModal
       const formations: Record<string, Record<string, number[][]>> = {
         '4-3-3': {


### PR DESCRIPTION
## Summary
- default sizeSettings now start at `medium`
- board store defaults token, object and formation sizes to `medium` instead of `large`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8a0656ee083298450397bbfb8263b