### PR TITLE
fix: allow small tokens to reach field edges

### DIFF
--- a/src/hooks/usePointerInteractions.ts
+++ b/src/hooks/usePointerInteractions.ts
@@ -3,6 +3,13 @@ import { useBoardStore } from './useBoardStore';
 import { Token, Point } from '../types';
 import { clampToField, snapToGrid, screenToSVG } from '../lib/geometry';
 
+const getTokenRadius = (token: Token): number => {
+  const objectType = token.type || 'player';
+  const baseRadius = objectType === 'player' ? 3 : objectType === 'ball' ? 2 : objectType === 'cone' ? 2 : 3;
+  const sizeMultiplier = token.size === 'small' ? 0.5 : token.size === 'medium' ? 0.8 : 1;
+  return baseRadius * sizeMultiplier;
+};
+
 interface DragState {
   isDragging: boolean;
   dragStartPoint: Point | null;
@@ -174,7 +181,9 @@ export const usePointerInteractions = (
         if (gridSnap) {
           newPosition = snapToGrid(newPosition);
         }
-        newPosition = clampToField(newPosition, fieldWidth, fieldHeight);
+        const token = useBoardStore.getState().tokens.find(t => t.id === id);
+        const margin = token ? getTokenRadius(token) : 5;
+        newPosition = clampToField(newPosition, fieldWidth, fieldHeight, margin);
         updateToken(id, newPosition);
         if (recording) {
           addTokenPathPoint(id, newPosition);

--- a/src/lib/geometry.ts
+++ b/src/lib/geometry.ts
@@ -11,8 +11,12 @@ export const snapToGrid = (point: Point, gridSize: number = 24): Point => {
   };
 };
 
-export const clampToField = (point: Point, fieldWidth: number, fieldHeight: number): Point => {
-  const margin = 5; // margin from field edges
+export const clampToField = (
+  point: Point,
+  fieldWidth: number,
+  fieldHeight: number,
+  margin: number = 5
+): Point => {
   return {
     x: Math.max(margin, Math.min(fieldWidth - margin, point.x)),
     y: Math.max(margin, Math.min(fieldHeight - margin, point.y)),


### PR DESCRIPTION
## Summary
- clamp field bounds with configurable margin
- base token margin on token radius during dragging

## Testing
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8a43db4b08329b8c731ec518ecdba