### PR TITLE
Add Equipo navigation button

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "clsx": "^2.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "zustand": "^4.4.7"
+    "zustand": "^4.4.7",
+    "dexie": "^3.2.4",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/src/EquipoPage.tsx
+++ b/src/EquipoPage.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import { createPlayer, listPlayers, deletePlayer } from "@/lib/players";
+import { Foot, Position, Player } from "@/types/squad";
+
+const ALL_POS: Position[] = ["POR","LD","LI","DFC","MCD","MC","MCO","ED","EI","DC","SD"];
+const FEET: Foot[] = ["diestro","zurdo","ambidiestro"];
+
+export default function EquipoPage() {
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  const [nombre, setNombre] = useState("");
+  const [dorsal, setDorsal] = useState<number | "">("");
+  const [pie, setPie] = useState<Foot>("diestro");
+  const [posiciones, setPosiciones] = useState<Position[]>([]);
+  const [altura, setAltura] = useState<number | "">("");
+
+  useEffect(() => {
+    (async () => {
+      const data = await listPlayers();
+      data.sort((a,b) => a.dorsal - b.dorsal);
+      setPlayers(data);
+      setLoading(false);
+    })();
+  }, []);
+
+  function togglePos(pos: Position) {
+    setPosiciones(prev =>
+      prev.includes(pos) ? prev.filter(p => p !== pos) : [...prev, pos]
+    );
+  }
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    try {
+      const nuevo = await createPlayer({
+        nombre: nombre.trim(),
+        dorsal: typeof dorsal === "number" ? dorsal : parseInt(String(dorsal),10),
+        pie,
+        posiciones,
+        altura_cm: typeof altura === "number" ? altura : (altura ? parseInt(String(altura),10) : undefined),
+      });
+      const data = [...players, nuevo].sort((a,b) => a.dorsal - b.dorsal);
+      setPlayers(data);
+      setNombre(""); setDorsal(""); setPie("diestro"); setPosiciones([]); setAltura("");
+    } catch (e: any) {
+      setErr(e.message ?? "Error al crear jugador");
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm("¿Eliminar jugador?")) return;
+    await deletePlayer(id);
+    setPlayers(prev => prev.filter(p => p.id !== id));
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-4">
+      <h1 className="text-2xl font-semibold mb-4">Equipo</h1>
+
+      <form onSubmit={handleAdd} className="space-y-3 border rounded p-4 mb-6">
+        <div>
+          <label className="block text-sm">Nombre *</label>
+          <input value={nombre} onChange={e=>setNombre(e.target.value)} className="w-full border rounded p-2" required />
+        </div>
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <label className="block text-sm">Dorsal *</label>
+            <input type="number" min={1} value={dorsal} onChange={e=>setDorsal(e.target.value===""?"":Number(e.target.value))} className="w-full border rounded p-2" required />
+          </div>
+          <div>
+            <label className="block text-sm">Pie *</label>
+            <select value={pie} onChange={e=>setPie(e.target.value as Foot)} className="w-full border rounded p-2">
+              {FEET.map(f => <option key={f} value={f}>{f}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm">Altura (cm)</label>
+            <input type="number" min={100} max={230} value={altura} onChange={e=>setAltura(e.target.value===""?"":Number(e.target.value))} className="w-full border rounded p-2" />
+          </div>
+        </div>
+
+        <div>
+          <span className="block text-sm mb-1">Posiciones *</span>
+          <div className="grid grid-cols-6 gap-2">
+            {ALL_POS.map(p => (
+              <label key={p} className="flex items-center gap-2 text-sm">
+                <input type="checkbox" checked={posiciones.includes(p)} onChange={()=>togglePos(p)} />
+                {p}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {err && <div className="text-red-600 text-sm">{err}</div>}
+
+        <button type="submit" className="px-4 py-2 rounded bg-black text-white">Añadir jugador</button>
+      </form>
+
+      <h2 className="text-xl font-medium mb-2">Jugadores ({players.length})</h2>
+      {loading ? <p>Cargando…</p> : (
+        <ul className="divide-y border rounded">
+          {players.map(p => (
+            <li key={p.id} className="p-3 flex items-center justify-between">
+              <div>
+                <div className="font-medium">#{p.dorsal} {p.nombre}</div>
+                <div className="text-sm text-gray-600">
+                  Pie: {p.pie} · Pos: {p.posiciones.join(", ")} {p.altura_cm ? `· ${p.altura_cm} cm` : ""}
+                </div>
+              </div>
+              <button onClick={()=>handleDelete(p.id)} className="text-red-600 text-sm">Eliminar</button>
+            </li>
+          ))}
+          {players.length===0 && <li className="p-3 text-sm text-gray-600">Aún no hay jugadores.</li>}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -337,7 +337,13 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 
       {/* Right Section: Actions */}
       <div className="flex items-center gap-2">
-        <button 
+        <a
+          href="/equipo"
+          className="control-btn"
+        >
+          Equipo
+        </a>
+        <button
           className="control-btn"
           onClick={onShowFormations}
         >

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,14 @@
+import Dexie, { Table } from "dexie";
+import { Player } from "@/types/squad";
+
+export class AppDB extends Dexie {
+  players!: Table<Player, string>;
+  constructor() {
+    super("tacticaDB");
+    this.version(1).stores({
+      players: "id, dorsal, nombre" // índice por dorsal para comprobar duplicados
+    });
+  }
+}
+
+export const db = new AppDB();

--- a/src/lib/players.ts
+++ b/src/lib/players.ts
@@ -1,0 +1,24 @@
+import { db } from "./db";
+import { Player } from "@/types/squad";
+import { v4 as uuid } from "uuid";
+
+export async function listPlayers(): Promise<Player[]> {
+  return db.players.toArray();
+}
+
+export async function createPlayer(p: Omit<Player,"id">): Promise<Player> {
+  if (!p.nombre?.trim()) throw new Error("El nombre es obligatorio");
+  if (!Number.isInteger(p.dorsal) || p.dorsal <= 0) throw new Error("Dorsal inválido");
+  if (!p.posiciones?.length) throw new Error("Debe incluir al menos una posición");
+
+  const existing = await db.players.where("dorsal").equals(p.dorsal).first();
+  if (existing) throw new Error(`El dorsal ${p.dorsal} ya está en uso`);
+
+  const nuevo: Player = { id: uuid(), ...p };
+  await db.players.add(nuevo);
+  return nuevo;
+}
+
+export async function deletePlayer(id: string): Promise<void> {
+  await db.players.delete(id);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
+import EquipoPage from './EquipoPage.tsx'
 import './styles/index.css'
 
 // Register service worker
@@ -16,8 +17,12 @@ if ('serviceWorker' in navigator) {
   });
 }
 
+const Root = () => (
+  window.location.pathname.startsWith('/equipo') ? <EquipoPage /> : <App />
+)
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <Root />
   </React.StrictMode>,
 )

--- a/src/types/squad.ts
+++ b/src/types/squad.ts
@@ -1,0 +1,19 @@
+export type Foot = "diestro" | "zurdo" | "ambidiestro";
+export type Position = "POR"|"LD"|"LI"|"DFC"|"MCD"|"MC"|"MCO"|"ED"|"EI"|"DC"|"SD";
+
+export interface Player {
+  id: string;          // uuid v4
+  nombre: string;
+  dorsal: number;      // entero > 0
+  pie: Foot;
+  posiciones: Position[]; // al menos 1
+  altura_cm?: number;
+  velocidad?: number;     // opcional 0..100
+  notas?: string;
+}
+
+export interface Squad {
+  id: string;         // uuid
+  nombre: string;     // p.ej. "Senior A 24/25"
+  jugadores: Player[]; // (nota: luego players irán en tabla propia)
+}

--- a/src/types/uuid.d.ts
+++ b/src/types/uuid.d.ts
@@ -1,0 +1,3 @@
+declare module "uuid" {
+  export function v4(): string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vercel.json
+++ b/vercel.json
@@ -25,5 +25,8 @@
         }
       ]
     }
+  ],
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
   ]
 }


### PR DESCRIPTION
## Summary
- add "Equipo" button in toolbar linking to `/equipo`
- route `/equipo` in Vite app to render EquipoPage for local player management
- add rewrite rule in vercel.json for client-side routing

## Testing
- `npm run type-check` *(fails: Cannot find module 'dexie')*
- `npm run build` *(fails: Cannot find module 'dexie')*


------
https://chatgpt.com/codex/tasks/task_e_68b980433fe08329a3a2b953c7e5b677