### PR TITLE
Add player technical attributes and editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "clsx": "^2.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "zustand": "^4.4.7"
+    "zustand": "^4.4.7",
+    "dexie": "^3.2.4",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/src/EquipoPage.tsx
+++ b/src/EquipoPage.tsx
@@ -1,0 +1,507 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  createPlayer,
+  listPlayers,
+  deletePlayer,
+  updatePlayer,
+} from "@/lib/players";
+import { ensureCurrentSquad, listSquads, setCurrentSquadId } from "@/lib/squads";
+import { Foot, Position, Player, Squad } from "@/types/squad";
+
+const ALL_POS: Position[] = ["POR","LD","LI","DFC","MCD","MC","MCO","ED","EI","DC","SD"];
+const FEET: Foot[] = ["diestro","zurdo","ambidiestro"];
+
+export default function EquipoPage() {
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  const [squads, setSquads] = useState<Squad[]>([]);
+  const [currentSquad, setCurrentSquad] = useState<string>("");
+
+  const [nombre, setNombre] = useState("");
+  const [dorsal, setDorsal] = useState<number | "">("");
+  const [pie, setPie] = useState<Foot>("diestro");
+  const [posiciones, setPosiciones] = useState<Position[]>([]);
+  const [altura, setAltura] = useState<number | "">("");
+  const [editing, setEditing] = useState<Player | null>(null);
+  const [editNombre, setEditNombre] = useState("");
+  const [editDorsal, setEditDorsal] = useState<number | "">("");
+  const [editPie, setEditPie] = useState<Foot>("diestro");
+  const [editPosiciones, setEditPosiciones] = useState<Position[]>([]);
+  const [editAltura, setEditAltura] = useState<number | "">("");
+  const [velocidad, setVelocidad] = useState(0);
+  const [resistencia, setResistencia] = useState(0);
+  const [pase, setPase] = useState(0);
+  const [regate, setRegate] = useState(0);
+  const [tiro, setTiro] = useState(0);
+  const [defensa, setDefensa] = useState(0);
+  const [estadoFisico, setEstadoFisico] = useState(0);
+  const [notas, setNotas] = useState("");
+  const [editErr, setEditErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const id = await ensureCurrentSquad();
+      const s = await listSquads();
+      setSquads(s);
+      setCurrentSquad(id);
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!currentSquad) return;
+    (async () => {
+      setLoading(true);
+      const data = await listPlayers(currentSquad);
+      data.sort((a, b) => a.dorsal - b.dorsal);
+      setPlayers(data);
+      setLoading(false);
+    })();
+  }, [currentSquad]);
+
+  function togglePos(pos: Position) {
+    setPosiciones(prev =>
+      prev.includes(pos) ? prev.filter(p => p !== pos) : [...prev, pos]
+    );
+  }
+
+  function toggleEditPos(pos: Position) {
+    setEditPosiciones(prev =>
+      prev.includes(pos) ? prev.filter(p => p !== pos) : [...prev, pos]
+    );
+  }
+
+  function onChangeSquad(id: string) {
+    setCurrentSquad(id);
+    setCurrentSquadId(id);
+  }
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    try {
+      const nuevo = await createPlayer(currentSquad, {
+        nombre: nombre.trim(),
+        dorsal:
+          typeof dorsal === "number" ? dorsal : parseInt(String(dorsal), 10),
+        pie,
+        posiciones,
+        altura_cm:
+          typeof altura === "number"
+            ? altura
+            : altura
+            ? parseInt(String(altura), 10)
+            : undefined,
+      });
+      const data = [...players, nuevo].sort((a, b) => a.dorsal - b.dorsal);
+      setPlayers(data);
+      setNombre("");
+      setDorsal("");
+      setPie("diestro");
+      setPosiciones([]);
+      setAltura("");
+    } catch (e: any) {
+      setErr(e.message ?? "Error al crear jugador");
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm("¿Eliminar jugador?")) return;
+    await deletePlayer(id);
+    setPlayers(prev => prev.filter(p => p.id !== id));
+  }
+
+  function startEdit(p: Player) {
+    setEditing(p);
+    setEditNombre(p.nombre);
+    setEditDorsal(p.dorsal);
+    setEditPie(p.pie);
+    setEditPosiciones(p.posiciones);
+    setEditAltura(p.altura_cm ?? "");
+    setVelocidad(p.velocidad ?? 0);
+    setResistencia(p.resistencia ?? 0);
+    setPase(p.pase ?? 0);
+    setRegate(p.regate ?? 0);
+    setTiro(p.tiro ?? 0);
+    setDefensa(p.defensa ?? 0);
+    setEstadoFisico(p.estadoFisico ?? 0);
+    setNotas(p.notas ?? "");
+    setEditErr(null);
+  }
+
+  async function saveEdit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!editing) return;
+    setEditErr(null);
+    if (!editNombre.trim()) {
+      setEditErr("El nombre es obligatorio");
+      return;
+    }
+    const dorsalNum =
+      typeof editDorsal === "number"
+        ? editDorsal
+        : parseInt(String(editDorsal), 10);
+    if (!Number.isInteger(dorsalNum) || dorsalNum <= 0) {
+      setEditErr("Dorsal inválido");
+      return;
+    }
+    if (!editPosiciones.length) {
+      setEditErr("Debe incluir al menos una posición");
+      return;
+    }
+    if (
+      players.some(
+        pl => pl.id !== editing.id && pl.dorsal === dorsalNum
+      )
+    ) {
+      setEditErr(`El dorsal ${dorsalNum} ya está en uso en este equipo`);
+      return;
+    }
+
+    const numAttrs = [
+      velocidad,
+      resistencia,
+      pase,
+      regate,
+      tiro,
+      defensa,
+      estadoFisico,
+    ];
+    if (numAttrs.some(n => n < 0 || n > 100)) {
+      setEditErr("Atributos entre 0 y 100");
+      return;
+    }
+
+    await updatePlayer(editing.id, {
+      nombre: editNombre.trim(),
+      dorsal: dorsalNum,
+      pie: editPie,
+      posiciones: editPosiciones,
+      altura_cm:
+        typeof editAltura === "number"
+          ? editAltura
+          : editAltura
+          ? parseInt(String(editAltura), 10)
+          : undefined,
+      velocidad,
+      resistencia,
+      pase,
+      regate,
+      tiro,
+      defensa,
+      estadoFisico,
+      notas: notas.trim() ? notas : undefined,
+    });
+
+    const data = await listPlayers(currentSquad);
+    data.sort((a, b) => a.dorsal - b.dorsal);
+    setPlayers(data);
+    setEditing(null);
+  }
+
+  return (
+      <div className="mx-auto max-w-3xl p-4">
+        <button onClick={() => window.history.back()} className="mb-4 text-sm underline">
+          ← Volver
+        </button>
+        <h1 className="text-2xl font-semibold mb-4">Equipo</h1>
+
+        <div className="mb-4">
+          <label className="block text-sm">Equipo</label>
+          <div className="flex items-center gap-2">
+            <select
+              value={currentSquad}
+              onChange={(e) => onChangeSquad(e.target.value)}
+              className="border rounded p-2 bg-white text-black"
+            >
+              {squads.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.nombre}
+                </option>
+              ))}
+            </select>
+            <a href="/equipos" className="text-sm underline">Gestionar equipos</a>
+          </div>
+        </div>
+
+        <form onSubmit={handleAdd} className="space-y-3 border rounded p-4 mb-6">
+        <div>
+          <label className="block text-sm">Nombre *</label>
+          <input value={nombre} onChange={e=>setNombre(e.target.value)} className="w-full border rounded p-2 bg-white text-black" required />
+        </div>
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <label className="block text-sm">Dorsal *</label>
+            <input type="number" min={1} value={dorsal} onChange={e=>setDorsal(e.target.value===""?"":Number(e.target.value))} className="w-full border rounded p-2 bg-white text-black" required />
+          </div>
+          <div>
+            <label className="block text-sm">Pie *</label>
+            <select value={pie} onChange={e=>setPie(e.target.value as Foot)} className="w-full border rounded p-2 bg-white text-black">
+              {FEET.map(f => <option key={f} value={f}>{f}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm">Altura (cm)</label>
+            <input type="number" min={100} max={230} value={altura} onChange={e=>setAltura(e.target.value===""?"":Number(e.target.value))} className="w-full border rounded p-2 bg-white text-black" />
+          </div>
+        </div>
+
+        <div>
+          <span className="block text-sm mb-1">Posiciones *</span>
+          <div className="grid grid-cols-6 gap-2">
+            {ALL_POS.map(p => (
+              <label key={p} className="flex items-center gap-2 text-sm">
+                <input type="checkbox" checked={posiciones.includes(p)} onChange={()=>togglePos(p)} />
+                {p}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {err && <div className="text-red-600 text-sm">{err}</div>}
+
+        <button type="submit" className="px-4 py-2 rounded bg-black text-white">Añadir jugador</button>
+      </form>
+
+      <h2 className="text-xl font-medium mb-2">Jugadores ({players.length})</h2>
+      {loading ? (
+        <p>Cargando…</p>
+      ) : (
+        <ul className="divide-y border rounded">
+          {players.map((p) => (
+            <li key={p.id} className="p-3 flex items-center justify-between">
+              <div>
+                <div className="font-medium">#{p.dorsal} {p.nombre}</div>
+                <div className="text-sm text-gray-600">
+                  Pie: {p.pie} · Pos: {p.posiciones.join(", ")} {p.altura_cm ? `· ${p.altura_cm} cm` : ""}
+                </div>
+                {(p.velocidad != null || p.resistencia != null || p.pase != null || p.regate != null || p.tiro != null || p.defensa != null || p.estadoFisico != null) && (
+                  <div className="text-xs text-gray-500">
+                    {`Vel ${p.velocidad ?? 0} · Res ${p.resistencia ?? 0} · Pase ${p.pase ?? 0} · Reg ${p.regate ?? 0} · Tiro ${p.tiro ?? 0} · Def ${p.defensa ?? 0} · EF ${p.estadoFisico ?? 0}`}
+                  </div>
+                )}
+                {p.notas && <div className="text-xs text-gray-500">Notas: {p.notas}</div>}
+              </div>
+              <div className="flex gap-2 text-sm">
+                <button onClick={() => startEdit(p)} className="text-blue-600">
+                  Editar
+                </button>
+                <button
+                  onClick={() => handleDelete(p.id)}
+                  className="text-red-600"
+                >
+                  Eliminar
+                </button>
+              </div>
+            </li>
+          ))}
+          {players.length === 0 && (
+            <li className="p-3 text-sm text-gray-600">Aún no hay jugadores.</li>
+          )}
+        </ul>
+      )}
+
+      {editing && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <form
+            onSubmit={saveEdit}
+            className="bg-white text-black p-4 rounded space-y-3 max-w-lg w-full mx-2"
+          >
+            <h3 className="text-lg font-medium">Editar jugador</h3>
+            <div>
+              <label className="block text-sm">Nombre *</label>
+              <input
+                value={editNombre}
+                onChange={(e) => setEditNombre(e.target.value)}
+                className="w-full border rounded p-2 bg-white text-black"
+                required
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-3">
+              <div>
+                <label className="block text-sm">Dorsal *</label>
+                <input
+                  type="number"
+                  min={1}
+                  value={editDorsal}
+                  onChange={(e) =>
+                    setEditDorsal(
+                      e.target.value === "" ? "" : Number(e.target.value)
+                    )
+                  }
+                  className="w-full border rounded p-2 bg-white text-black"
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm">Pie *</label>
+                <select
+                  value={editPie}
+                  onChange={(e) => setEditPie(e.target.value as Foot)}
+                  className="w-full border rounded p-2 bg-white text-black"
+                >
+                  {FEET.map((f) => (
+                    <option key={f} value={f}>
+                      {f}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm">Altura (cm)</label>
+                <input
+                  type="number"
+                  min={100}
+                  max={230}
+                  value={editAltura}
+                  onChange={(e) =>
+                    setEditAltura(
+                      e.target.value === "" ? "" : Number(e.target.value)
+                    )
+                  }
+                  className="w-full border rounded p-2 bg-white text-black"
+                />
+              </div>
+            </div>
+
+            <div>
+              <span className="block text-sm mb-1">Posiciones *</span>
+              <div className="grid grid-cols-6 gap-2">
+                {ALL_POS.map((p) => (
+                  <label key={p} className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={editPosiciones.includes(p)}
+                      onChange={() => toggleEditPos(p)}
+                    />
+                    {p}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm">Velocidad</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={velocidad}
+                  onChange={(e) => setVelocidad(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{velocidad}</span>
+              </div>
+              <div>
+                <label className="block text-sm">Resistencia</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={resistencia}
+                  onChange={(e) => setResistencia(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{resistencia}</span>
+              </div>
+              <div>
+                <label className="block text-sm">Pase</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={pase}
+                  onChange={(e) => setPase(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{pase}</span>
+              </div>
+              <div>
+                <label className="block text-sm">Regate</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={regate}
+                  onChange={(e) => setRegate(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{regate}</span>
+              </div>
+              <div>
+                <label className="block text-sm">Tiro</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={tiro}
+                  onChange={(e) => setTiro(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{tiro}</span>
+              </div>
+              <div>
+                <label className="block text-sm">Defensa</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={defensa}
+                  onChange={(e) => setDefensa(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{defensa}</span>
+              </div>
+              <div>
+                <label className="block text-sm">Estado físico</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={estadoFisico}
+                  onChange={(e) => setEstadoFisico(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{estadoFisico}</span>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm">Notas</label>
+              <textarea
+                value={notas}
+                onChange={(e) => setNotas(e.target.value)}
+                className="w-full border rounded p-2 bg-white text-black"
+                rows={3}
+              />
+            </div>
+
+            {editErr && (
+              <div className="text-red-600 text-sm">{editErr}</div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                onClick={() => setEditing(null)}
+                className="px-4 py-2 rounded border"
+              >
+                Cancelar
+              </button>
+              <button
+                type="submit"
+                className="px-4 py-2 rounded bg-black text-white"
+              >
+                Guardar
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/EquiposPage.tsx
+++ b/src/EquiposPage.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import {
+  listSquads,
+  createSquad,
+  deleteSquad,
+  renameSquad,
+  setCurrentSquadId,
+  ensureCurrentSquad,
+} from "@/lib/squads";
+import { Squad } from "@/types/squad";
+
+export default function EquiposPage() {
+  const [items, setItems] = useState<Squad[]>([]);
+  const [nombre, setNombre] = useState("");
+  const [err, setErr] = useState<string | null>(null);
+
+  async function refresh() {
+    const s = await listSquads();
+    setItems(s);
+    await ensureCurrentSquad();
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  async function add(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    try {
+      await createSquad(nombre);
+      setNombre("");
+      await refresh();
+    } catch (e: any) {
+      setErr(e.message ?? "Error");
+    }
+  }
+
+  async function setActual(id: string) {
+    setCurrentSquadId(id);
+    alert("Equipo seleccionado como actual");
+  }
+
+  async function ren(id: string) {
+    const nuevo = prompt("Nuevo nombre:");
+    if (!nuevo) return;
+    await renameSquad(id, nuevo);
+    await refresh();
+  }
+
+  async function del(id: string) {
+    if (!confirm("¿Eliminar equipo? Solo si no tiene jugadores.")) return;
+    try {
+      await deleteSquad(id);
+      await refresh();
+    } catch (e: any) {
+      alert(e.message ?? "No se pudo eliminar");
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl p-4">
+      <button onClick={() => window.history.back()} className="mb-4 text-sm underline">
+        ← Volver
+      </button>
+      <h1 className="text-2xl font-semibold mb-4">Equipos</h1>
+      <form onSubmit={add} className="flex gap-2 mb-4">
+        <input
+          className="border rounded p-2 flex-1 bg-white text-black"
+          placeholder="Nombre del equipo"
+          value={nombre}
+          onChange={(e) => setNombre(e.target.value)}
+        />
+        <button className="px-4 py-2 bg-black text-white rounded">Crear</button>
+      </form>
+      {err && <div className="text-red-600 text-sm mb-2">{err}</div>}
+      <ul className="divide-y border rounded">
+        {items.map((s) => (
+          <li key={s.id} className="p-3 flex items-center justify-between">
+            <div className="font-medium">{s.nombre}</div>
+            <div className="flex gap-3 text-sm">
+              <button onClick={() => setActual(s.id)} className="underline">
+                Seleccionar
+              </button>
+              <button onClick={() => ren(s.id)} className="underline">
+                Renombrar
+              </button>
+              <button
+                onClick={() => del(s.id)}
+                className="text-red-600 underline"
+              >
+                Eliminar
+              </button>
+            </div>
+          </li>
+        ))}
+        {items.length === 0 && (
+          <li className="p-3 text-sm text-gray-600">Aún no hay equipos.</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -337,7 +337,19 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 
       {/* Right Section: Actions */}
       <div className="flex items-center gap-2">
-        <button 
+        <a
+          href="/equipo"
+          className="control-btn"
+        >
+          Equipo
+        </a>
+        <a
+          href="/equipos"
+          className="control-btn"
+        >
+          Equipos
+        </a>
+        <button
           className="control-btn"
           onClick={onShowFormations}
         >

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,33 @@
+import Dexie, { Table } from "dexie";
+import { Player, Squad } from "@/types/squad";
+
+export class AppDB extends Dexie {
+  players!: Table<Player, string>;
+  squads!: Table<Squad, string>;
+  constructor() {
+    super("tacticaDB");
+    // v1: solo jugadores
+    this.version(1).stores({
+      players: "id, dorsal, nombre"
+    });
+    // v2: añadimos squads y los índices por squad
+    this.version(2)
+      .stores({
+        squads: "id, nombre",
+        players: "id, squadId, dorsal, nombre"
+      })
+      .upgrade(async (tx: any) => {
+        const squads = tx.table("squads") as Table<Squad, string>;
+        const players = tx.table("players") as Table<Player, string>;
+        const defaultId =
+          (globalThis as any).crypto?.randomUUID?.() ??
+          (await import("uuid")).v4();
+        await squads.add({ id: defaultId, nombre: "Equipo principal" });
+        await players.toCollection().modify((p: any) => {
+          if (!p.squadId) p.squadId = defaultId;
+        });
+      });
+  }
+}
+
+export const db = new AppDB();

--- a/src/lib/players.ts
+++ b/src/lib/players.ts
@@ -1,0 +1,38 @@
+import { db } from "./db";
+import { Player } from "@/types/squad";
+import { v4 as uuid } from "uuid";
+
+export async function listPlayers(squadId: string): Promise<Player[]> {
+  return db.players.where("squadId").equals(squadId).toArray();
+}
+
+export async function createPlayer(
+  squadId: string,
+  p: Omit<Player, "id" | "squadId">
+): Promise<Player> {
+  if (!p.nombre?.trim()) throw new Error("El nombre es obligatorio");
+  if (!Number.isInteger(p.dorsal) || p.dorsal <= 0) throw new Error("Dorsal inválido");
+  if (!p.posiciones?.length) throw new Error("Debe incluir al menos una posición");
+
+  const existing = await db.players
+    .where("squadId")
+    .equals(squadId)
+    .and((pl: Player) => pl.dorsal === p.dorsal)
+    .first();
+  if (existing) throw new Error(`El dorsal ${p.dorsal} ya está en uso en este equipo`);
+
+  const nuevo: Player = { id: uuid(), squadId, ...p };
+  await db.players.add(nuevo);
+  return nuevo;
+}
+
+export async function updatePlayer(
+  id: string,
+  changes: Partial<Player>
+): Promise<void> {
+  await db.players.update(id, changes);
+}
+
+export async function deletePlayer(id: string): Promise<void> {
+  await db.players.delete(id);
+}

--- a/src/lib/squads.ts
+++ b/src/lib/squads.ts
@@ -1,0 +1,51 @@
+import { db } from "./db";
+import { Squad } from "@/types/squad";
+import { v4 as uuid } from "uuid";
+
+const CURRENT_SQUAD_KEY = "tactica.currentSquadId";
+
+export async function listSquads(): Promise<Squad[]> {
+  return db.squads.toArray();
+}
+
+export async function createSquad(nombre: string): Promise<Squad> {
+  const s: Squad = { id: uuid(), nombre: nombre.trim() };
+  if (!s.nombre) throw new Error("El nombre es obligatorio");
+  await db.squads.add(s);
+  return s;
+}
+
+export async function renameSquad(id: string, nombre: string): Promise<void> {
+  if (!nombre.trim()) throw new Error("Nombre inválido");
+  await db.squads.update(id, { nombre: nombre.trim() });
+}
+
+export async function deleteSquad(id: string): Promise<void> {
+  const count = await db.players.where("squadId").equals(id).count();
+  if (count > 0) throw new Error("No puedes eliminar un equipo con jugadores");
+  await db.squads.delete(id);
+  const current = getCurrentSquadId();
+  if (current === id) localStorage.removeItem(CURRENT_SQUAD_KEY);
+}
+
+export function setCurrentSquadId(id: string) {
+  localStorage.setItem(CURRENT_SQUAD_KEY, id);
+}
+
+export function getCurrentSquadId(): string | null {
+  return localStorage.getItem(CURRENT_SQUAD_KEY);
+}
+
+export async function ensureCurrentSquad(): Promise<string> {
+  let id = getCurrentSquadId();
+  if (id) return id;
+  const all = await listSquads();
+  if (all.length === 0) {
+    const s = await createSquad("Equipo principal");
+    setCurrentSquadId(s.id);
+    return s.id;
+  }
+  setCurrentSquadId(all[0].id);
+  return all[0].id;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,9 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './styles/index.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import EquipoPage from './EquipoPage.tsx';
+import EquiposPage from './EquiposPage.tsx';
+import './styles/index.css';
 
 // Register service worker
 if ('serviceWorker' in navigator) {
@@ -16,8 +18,15 @@ if ('serviceWorker' in navigator) {
   });
 }
 
+const Root = () => {
+  const path = window.location.pathname;
+  if (path.startsWith('/equipos')) return <EquiposPage />;
+  if (path.startsWith('/equipo')) return <EquipoPage />;
+  return <App />;
+};
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <Root />
   </React.StrictMode>,
 )

--- a/src/types/squad.ts
+++ b/src/types/squad.ts
@@ -1,0 +1,27 @@
+export type Foot = "diestro" | "zurdo" | "ambidiestro";
+export type Position = "POR"|"LD"|"LI"|"DFC"|"MCD"|"MC"|"MCO"|"ED"|"EI"|"DC"|"SD";
+
+export interface Player {
+  id: string;
+  squadId: string;
+  nombre: string;
+  dorsal: number;
+  pie: Foot;
+  posiciones: Position[];
+  altura_cm?: number;
+  velocidad?: number;
+  resistencia?: number;
+  pase?: number;
+  regate?: number;
+  tiro?: number;
+  defensa?: number;
+  estadoFisico?: number;
+  notas?: string;
+}
+
+export interface Squad {
+  id: string;
+  nombre: string;
+  categoria?: string;
+  temporada?: string;
+}

--- a/src/types/uuid.d.ts
+++ b/src/types/uuid.d.ts
@@ -1,0 +1,3 @@
+declare module "uuid" {
+  export function v4(): string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vercel.json
+++ b/vercel.json
@@ -25,5 +25,8 @@
         }
       ]
     }
+  ],
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
+import { resolve } from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src')
+    }
+  },
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- extend Player type with technical skills (speed, endurance, passing, etc.)
- add updatePlayer helper for modifying player records
- enable editing players via modal with sliders for skills and notes
- ensure edit-player modal uses dark text on a light background for readability
- add Next.js client directive and Tailwind styling for skill sliders

## Testing
- `npm run type-check` *(fails: Cannot find module 'dexie' or its corresponding type declarations)*
- `npm run build` *(fails: Cannot find module 'dexie' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b980433fe08329a3a2b953c7e5b677