### PR TITLE
Add opponent scouting per squad

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "clsx": "^2.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "zustand": "^4.4.7"
+    "zustand": "^4.4.7",
+    "dexie": "^3.2.4",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/src/EquipoPage.tsx
+++ b/src/EquipoPage.tsx
@@ -1,0 +1,507 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  createPlayer,
+  listPlayers,
+  deletePlayer,
+  updatePlayer,
+} from "@/lib/players";
+import { ensureCurrentSquad, listSquads, setCurrentSquadId } from "@/lib/squads";
+import { Foot, Position, Player, Squad } from "@/types/squad";
+
+const ALL_POS: Position[] = ["POR","LD","LI","DFC","MCD","MC","MCO","ED","EI","DC","SD"];
+const FEET: Foot[] = ["diestro","zurdo","ambidiestro"];
+
+export default function EquipoPage() {
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  const [squads, setSquads] = useState<Squad[]>([]);
+  const [currentSquad, setCurrentSquad] = useState<string>("");
+
+  const [nombre, setNombre] = useState("");
+  const [dorsal, setDorsal] = useState<number | "">("");
+  const [pie, setPie] = useState<Foot>("diestro");
+  const [posiciones, setPosiciones] = useState<Position[]>([]);
+  const [altura, setAltura] = useState<number | "">("");
+  const [editing, setEditing] = useState<Player | null>(null);
+  const [editNombre, setEditNombre] = useState("");
+  const [editDorsal, setEditDorsal] = useState<number | "">("");
+  const [editPie, setEditPie] = useState<Foot>("diestro");
+  const [editPosiciones, setEditPosiciones] = useState<Position[]>([]);
+  const [editAltura, setEditAltura] = useState<number | "">("");
+  const [velocidad, setVelocidad] = useState(0);
+  const [resistencia, setResistencia] = useState(0);
+  const [pase, setPase] = useState(0);
+  const [regate, setRegate] = useState(0);
+  const [tiro, setTiro] = useState(0);
+  const [defensa, setDefensa] = useState(0);
+  const [estadoFisico, setEstadoFisico] = useState(0);
+  const [notas, setNotas] = useState("");
+  const [editErr, setEditErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const id = await ensureCurrentSquad();
+      const s = await listSquads();
+      setSquads(s);
+      setCurrentSquad(id);
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!currentSquad) return;
+    (async () => {
+      setLoading(true);
+      const data = await listPlayers(currentSquad);
+      data.sort((a, b) => a.dorsal - b.dorsal);
+      setPlayers(data);
+      setLoading(false);
+    })();
+  }, [currentSquad]);
+
+  function togglePos(pos: Position) {
+    setPosiciones(prev =>
+      prev.includes(pos) ? prev.filter(p => p !== pos) : [...prev, pos]
+    );
+  }
+
+  function toggleEditPos(pos: Position) {
+    setEditPosiciones(prev =>
+      prev.includes(pos) ? prev.filter(p => p !== pos) : [...prev, pos]
+    );
+  }
+
+  function onChangeSquad(id: string) {
+    setCurrentSquad(id);
+    setCurrentSquadId(id);
+  }
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    try {
+      const nuevo = await createPlayer(currentSquad, {
+        nombre: nombre.trim(),
+        dorsal:
+          typeof dorsal === "number" ? dorsal : parseInt(String(dorsal), 10),
+        pie,
+        posiciones,
+        altura_cm:
+          typeof altura === "number"
+            ? altura
+            : altura
+            ? parseInt(String(altura), 10)
+            : undefined,
+      });
+      const data = [...players, nuevo].sort((a, b) => a.dorsal - b.dorsal);
+      setPlayers(data);
+      setNombre("");
+      setDorsal("");
+      setPie("diestro");
+      setPosiciones([]);
+      setAltura("");
+    } catch (e: any) {
+      setErr(e.message ?? "Error al crear jugador");
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm("¿Eliminar jugador?")) return;
+    await deletePlayer(id);
+    setPlayers(prev => prev.filter(p => p.id !== id));
+  }
+
+  function startEdit(p: Player) {
+    setEditing(p);
+    setEditNombre(p.nombre);
+    setEditDorsal(p.dorsal);
+    setEditPie(p.pie);
+    setEditPosiciones(p.posiciones);
+    setEditAltura(p.altura_cm ?? "");
+    setVelocidad(p.velocidad ?? 0);
+    setResistencia(p.resistencia ?? 0);
+    setPase(p.pase ?? 0);
+    setRegate(p.regate ?? 0);
+    setTiro(p.tiro ?? 0);
+    setDefensa(p.defensa ?? 0);
+    setEstadoFisico(p.estadoFisico ?? 0);
+    setNotas(p.notas ?? "");
+    setEditErr(null);
+  }
+
+  async function saveEdit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!editing) return;
+    setEditErr(null);
+    if (!editNombre.trim()) {
+      setEditErr("El nombre es obligatorio");
+      return;
+    }
+    const dorsalNum =
+      typeof editDorsal === "number"
+        ? editDorsal
+        : parseInt(String(editDorsal), 10);
+    if (!Number.isInteger(dorsalNum) || dorsalNum <= 0) {
+      setEditErr("Dorsal inválido");
+      return;
+    }
+    if (!editPosiciones.length) {
+      setEditErr("Debe incluir al menos una posición");
+      return;
+    }
+    if (
+      players.some(
+        pl => pl.id !== editing.id && pl.dorsal === dorsalNum
+      )
+    ) {
+      setEditErr(`El dorsal ${dorsalNum} ya está en uso en este equipo`);
+      return;
+    }
+
+    const numAttrs = [
+      velocidad,
+      resistencia,
+      pase,
+      regate,
+      tiro,
+      defensa,
+      estadoFisico,
+    ];
+    if (numAttrs.some(n => n < 0 || n > 100)) {
+      setEditErr("Atributos entre 0 y 100");
+      return;
+    }
+
+    await updatePlayer(editing.id, {
+      nombre: editNombre.trim(),
+      dorsal: dorsalNum,
+      pie: editPie,
+      posiciones: editPosiciones,
+      altura_cm:
+        typeof editAltura === "number"
+          ? editAltura
+          : editAltura
+          ? parseInt(String(editAltura), 10)
+          : undefined,
+      velocidad,
+      resistencia,
+      pase,
+      regate,
+      tiro,
+      defensa,
+      estadoFisico,
+      notas: notas.trim() ? notas : undefined,
+    });
+
+    const data = await listPlayers(currentSquad);
+    data.sort((a, b) => a.dorsal - b.dorsal);
+    setPlayers(data);
+    setEditing(null);
+  }
+
+  return (
+      <div className="mx-auto max-w-3xl p-4">
+        <button onClick={() => window.history.back()} className="mb-4 text-sm underline">
+          ← Volver
+        </button>
+        <h1 className="text-2xl font-semibold mb-4">Equipo</h1>
+
+        <div className="mb-4">
+          <label className="block text-sm">Equipo</label>
+          <div className="flex items-center gap-2">
+            <select
+              value={currentSquad}
+              onChange={(e) => onChangeSquad(e.target.value)}
+              className="border rounded p-2 bg-white text-black"
+            >
+              {squads.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.nombre}
+                </option>
+              ))}
+            </select>
+            <a href="/equipos" className="text-sm underline">Gestionar equipos</a>
+          </div>
+        </div>
+
+        <form onSubmit={handleAdd} className="space-y-3 border rounded p-4 mb-6">
+        <div>
+          <label className="block text-sm">Nombre *</label>
+          <input value={nombre} onChange={e=>setNombre(e.target.value)} className="w-full border rounded p-2 bg-white text-black" required />
+        </div>
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <label className="block text-sm">Dorsal *</label>
+            <input type="number" min={1} value={dorsal} onChange={e=>setDorsal(e.target.value===""?"":Number(e.target.value))} className="w-full border rounded p-2 bg-white text-black" required />
+          </div>
+          <div>
+            <label className="block text-sm">Pie *</label>
+            <select value={pie} onChange={e=>setPie(e.target.value as Foot)} className="w-full border rounded p-2 bg-white text-black">
+              {FEET.map(f => <option key={f} value={f}>{f}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm">Altura (cm)</label>
+            <input type="number" min={100} max={230} value={altura} onChange={e=>setAltura(e.target.value===""?"":Number(e.target.value))} className="w-full border rounded p-2 bg-white text-black" />
+          </div>
+        </div>
+
+        <div>
+          <span className="block text-sm mb-1">Posiciones *</span>
+          <div className="grid grid-cols-6 gap-2">
+            {ALL_POS.map(p => (
+              <label key={p} className="flex items-center gap-2 text-sm">
+                <input type="checkbox" checked={posiciones.includes(p)} onChange={()=>togglePos(p)} />
+                {p}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {err && <div className="text-red-600 text-sm">{err}</div>}
+
+        <button type="submit" className="px-4 py-2 rounded bg-black text-white">Añadir jugador</button>
+      </form>
+
+      <h2 className="text-xl font-medium mb-2">Jugadores ({players.length})</h2>
+      {loading ? (
+        <p>Cargando…</p>
+      ) : (
+        <ul className="divide-y border rounded">
+          {players.map((p) => (
+            <li key={p.id} className="p-3 flex items-center justify-between">
+              <div>
+                <div className="font-medium">#{p.dorsal} {p.nombre}</div>
+                <div className="text-sm text-gray-600">
+                  Pie: {p.pie} · Pos: {p.posiciones.join(", ")} {p.altura_cm ? `· ${p.altura_cm} cm` : ""}
+                </div>
+                {(p.velocidad != null || p.resistencia != null || p.pase != null || p.regate != null || p.tiro != null || p.defensa != null || p.estadoFisico != null) && (
+                  <div className="text-xs text-gray-500">
+                    {`Vel ${p.velocidad ?? 0} · Res ${p.resistencia ?? 0} · Pase ${p.pase ?? 0} · Reg ${p.regate ?? 0} · Tiro ${p.tiro ?? 0} · Def ${p.defensa ?? 0} · EF ${p.estadoFisico ?? 0}`}
+                  </div>
+                )}
+                {p.notas && <div className="text-xs text-gray-500">Notas: {p.notas}</div>}
+              </div>
+              <div className="flex gap-2 text-sm">
+                <button onClick={() => startEdit(p)} className="text-blue-600">
+                  Editar
+                </button>
+                <button
+                  onClick={() => handleDelete(p.id)}
+                  className="text-red-600"
+                >
+                  Eliminar
+                </button>
+              </div>
+            </li>
+          ))}
+          {players.length === 0 && (
+            <li className="p-3 text-sm text-gray-600">Aún no hay jugadores.</li>
+          )}
+        </ul>
+      )}
+
+      {editing && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <form
+            onSubmit={saveEdit}
+            className="bg-white text-black p-4 rounded space-y-3 max-w-lg w-full mx-2"
+          >
+            <h3 className="text-lg font-medium">Editar jugador</h3>
+            <div>
+              <label className="block text-sm">Nombre *</label>
+              <input
+                value={editNombre}
+                onChange={(e) => setEditNombre(e.target.value)}
+                className="w-full border rounded p-2 bg-white text-black"
+                required
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-3">
+              <div>
+                <label className="block text-sm">Dorsal *</label>
+                <input
+                  type="number"
+                  min={1}
+                  value={editDorsal}
+                  onChange={(e) =>
+                    setEditDorsal(
+                      e.target.value === "" ? "" : Number(e.target.value)
+                    )
+                  }
+                  className="w-full border rounded p-2 bg-white text-black"
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm">Pie *</label>
+                <select
+                  value={editPie}
+                  onChange={(e) => setEditPie(e.target.value as Foot)}
+                  className="w-full border rounded p-2 bg-white text-black"
+                >
+                  {FEET.map((f) => (
+                    <option key={f} value={f}>
+                      {f}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm">Altura (cm)</label>
+                <input
+                  type="number"
+                  min={100}
+                  max={230}
+                  value={editAltura}
+                  onChange={(e) =>
+                    setEditAltura(
+                      e.target.value === "" ? "" : Number(e.target.value)
+                    )
+                  }
+                  className="w-full border rounded p-2 bg-white text-black"
+                />
+              </div>
+            </div>
+
+            <div>
+              <span className="block text-sm mb-1">Posiciones *</span>
+              <div className="grid grid-cols-6 gap-2">
+                {ALL_POS.map((p) => (
+                  <label key={p} className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={editPosiciones.includes(p)}
+                      onChange={() => toggleEditPos(p)}
+                    />
+                    {p}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm">Velocidad</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={velocidad}
+                  onChange={(e) => setVelocidad(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{velocidad}</span>
+              </div>
+              <div>
+                <label className="block text-sm">Resistencia</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={resistencia}
+                  onChange={(e) => setResistencia(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{resistencia}</span>
+              </div>
+              <div>
+                <label className="block text-sm">Pase</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={pase}
+                  onChange={(e) => setPase(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{pase}</span>
+              </div>
+              <div>
+                <label className="block text-sm">Regate</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={regate}
+                  onChange={(e) => setRegate(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{regate}</span>
+              </div>
+              <div>
+                <label className="block text-sm">Tiro</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={tiro}
+                  onChange={(e) => setTiro(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{tiro}</span>
+              </div>
+              <div>
+                <label className="block text-sm">Defensa</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={defensa}
+                  onChange={(e) => setDefensa(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{defensa}</span>
+              </div>
+              <div>
+                <label className="block text-sm">Estado físico</label>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={estadoFisico}
+                  onChange={(e) => setEstadoFisico(Number(e.target.value))}
+                  className="w-full"
+                />
+                <span>{estadoFisico}</span>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm">Notas</label>
+              <textarea
+                value={notas}
+                onChange={(e) => setNotas(e.target.value)}
+                className="w-full border rounded p-2 bg-white text-black"
+                rows={3}
+              />
+            </div>
+
+            {editErr && (
+              <div className="text-red-600 text-sm">{editErr}</div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                onClick={() => setEditing(null)}
+                className="px-4 py-2 rounded border"
+              >
+                Cancelar
+              </button>
+              <button
+                type="submit"
+                className="px-4 py-2 rounded bg-black text-white"
+              >
+                Guardar
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/EquiposPage.tsx
+++ b/src/EquiposPage.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import {
+  listSquads,
+  createSquad,
+  deleteSquad,
+  renameSquad,
+  setCurrentSquadId,
+  ensureCurrentSquad,
+} from "@/lib/squads";
+import { Squad } from "@/types/squad";
+
+export default function EquiposPage() {
+  const [items, setItems] = useState<Squad[]>([]);
+  const [nombre, setNombre] = useState("");
+  const [err, setErr] = useState<string | null>(null);
+
+  async function refresh() {
+    const s = await listSquads();
+    setItems(s);
+    await ensureCurrentSquad();
+  }
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  async function add(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    try {
+      await createSquad(nombre);
+      setNombre("");
+      await refresh();
+    } catch (e: any) {
+      setErr(e.message ?? "Error");
+    }
+  }
+
+  async function setActual(id: string) {
+    setCurrentSquadId(id);
+    alert("Equipo seleccionado como actual");
+  }
+
+  async function ren(id: string) {
+    const nuevo = prompt("Nuevo nombre:");
+    if (!nuevo) return;
+    await renameSquad(id, nuevo);
+    await refresh();
+  }
+
+  async function del(id: string) {
+    if (!confirm("¿Eliminar equipo? Solo si no tiene jugadores.")) return;
+    try {
+      await deleteSquad(id);
+      await refresh();
+    } catch (e: any) {
+      alert(e.message ?? "No se pudo eliminar");
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl p-4">
+      <button onClick={() => window.history.back()} className="mb-4 text-sm underline">
+        ← Volver
+      </button>
+      <h1 className="text-2xl font-semibold mb-4">Equipos</h1>
+      <form onSubmit={add} className="flex gap-2 mb-4">
+        <input
+          className="border rounded p-2 flex-1 bg-white text-black"
+          placeholder="Nombre del equipo"
+          value={nombre}
+          onChange={(e) => setNombre(e.target.value)}
+        />
+        <button className="px-4 py-2 bg-black text-white rounded">Crear</button>
+      </form>
+      {err && <div className="text-red-600 text-sm mb-2">{err}</div>}
+      <ul className="divide-y border rounded">
+        {items.map((s) => (
+          <li key={s.id} className="p-3 flex items-center justify-between">
+            <div className="font-medium">{s.nombre}</div>
+            <div className="flex gap-3 text-sm">
+              <button onClick={() => setActual(s.id)} className="underline">
+                Seleccionar
+              </button>
+              <button onClick={() => ren(s.id)} className="underline">
+                Renombrar
+              </button>
+              <button
+                onClick={() => del(s.id)}
+                className="text-red-600 underline"
+              >
+                Eliminar
+              </button>
+            </div>
+          </li>
+        ))}
+        {items.length === 0 && (
+          <li className="p-3 text-sm text-gray-600">Aún no hay equipos.</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/RivalesPage.tsx
+++ b/src/RivalesPage.tsx
@@ -1,0 +1,353 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Squad, OpponentScouting } from "@/types/squad";
+import { listSquads, ensureCurrentSquad, setCurrentSquadId } from "@/lib/squads";
+import { listOpponents, createOpponent, updateOpponent, deleteOpponent } from "@/lib/opponents";
+
+export default function RivalesPage() {
+  const [squads, setSquads] = useState<Squad[]>([]);
+  const [currentSquad, setCurrentSquad] = useState<string>("");
+  const [items, setItems] = useState<OpponentScouting[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [creatingName, setCreatingName] = useState("");
+
+  const [editing, setEditing] = useState<OpponentScouting | null>(null);
+  const [form, setForm] = useState<OpponentScouting | null>(null);
+  const isOpen = useMemo(() => !!editing && !!form, [editing, form]);
+
+  useEffect(() => {
+    (async () => {
+      const id = await ensureCurrentSquad();
+      const s = await listSquads();
+      setSquads(s);
+      setCurrentSquad(id);
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!currentSquad) return;
+    (async () => {
+      const list = await listOpponents(currentSquad);
+      setItems(list);
+    })();
+  }, [currentSquad]);
+
+  function onChangeSquad(id: string) {
+    setCurrentSquad(id);
+    setCurrentSquadId(id);
+  }
+
+  async function onCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    try {
+      const o = await createOpponent(currentSquad, creatingName);
+      setItems((prev) => [o, ...prev]);
+      setCreatingName("");
+    } catch (e: any) {
+      setErr(e.message ?? "Error al crear rival");
+    }
+  }
+
+  function openEdit(item: OpponentScouting) {
+    setEditing(item);
+    setForm({ ...item });
+  }
+
+  function closeModal() {
+    setEditing(null);
+    setForm(null);
+  }
+
+  function addChip(key: keyof OpponentScouting, value: string) {
+    if (!form) return;
+    const v = value.trim();
+    if (!v) return;
+    const arr = Array.isArray((form as any)[key])
+      ? ([...(form as any)[key]] as string[])
+      : [];
+    if (!arr.includes(v)) arr.push(v);
+    setForm({ ...form, [key]: arr } as OpponentScouting);
+  }
+
+  function removeChip(key: keyof OpponentScouting, idx: number) {
+    if (!form) return;
+    const arr = Array.isArray((form as any)[key])
+      ? ([...(form as any)[key]] as string[])
+      : [];
+    arr.splice(idx, 1);
+    setForm({ ...form, [key]: arr } as OpponentScouting);
+  }
+
+  async function onSave() {
+    if (!editing || !form) return;
+    if (!form.rival?.trim()) {
+      alert("El nombre del rival es obligatorio");
+      return;
+    }
+    await updateOpponent(editing.id, {
+      rival: form.rival.trim(),
+      sistemaHabitual: form.sistemaHabitual?.trim() ?? "",
+      fortalezas: form.fortalezas ?? [],
+      debilidades: form.debilidades ?? [],
+      jugadoresClave: form.jugadoresClave ?? [],
+      patrones: form.patrones ?? [],
+      notas: form.notas ?? "",
+    });
+    setItems((prev) => prev.map((it) => (it.id === editing.id ? { ...it, ...form } : it)));
+    closeModal();
+  }
+
+  async function onDelete(id: string) {
+    if (!confirm("¿Eliminar ficha de rival?")) return;
+    await deleteOpponent(id);
+    setItems((prev) => prev.filter((i) => i.id !== id));
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl p-4">
+      <button onClick={() => window.history.back()} className="mb-4 text-sm underline">
+        ← Volver
+      </button>
+      <h1 className="text-2xl font-semibold mb-4">Rivales</h1>
+
+      {/* Selector de equipo */}
+      <div className="mb-4">
+        <label className="block text-sm">Equipo</label>
+        <select
+          value={currentSquad}
+          onChange={(e) => onChangeSquad(e.target.value)}
+          className="border rounded p-2 bg-white text-black"
+        >
+          {squads.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.nombre}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Alta rápida de rival */}
+      <form onSubmit={onCreate} className="flex gap-2 mb-4">
+        <input
+          className="border rounded p-2 flex-1 bg-white text-black"
+          placeholder="Nombre del rival"
+          value={creatingName}
+          onChange={(e) => setCreatingName(e.target.value)}
+        />
+        <button className="px-4 py-2 bg-black text-white rounded">Añadir rival</button>
+      </form>
+      {err && <div className="text-red-600 text-sm mb-3">{err}</div>}
+
+      {/* Listado */}
+      <div className="space-y-3">
+        {items.map((item) => (
+          <div key={item.id} className="border rounded p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-lg font-medium">{item.rival}</div>
+                <div className="text-sm text-gray-600">
+                  Sistema habitual: {item.sistemaHabitual || "—"}
+                </div>
+              </div>
+              <div className="flex gap-3 text-sm">
+                <button className="underline" onClick={() => openEdit(item)}>
+                  Editar
+                </button>
+                <button
+                  className="text-red-600 underline"
+                  onClick={() => onDelete(item.id)}
+                >
+                  Eliminar
+                </button>
+              </div>
+            </div>
+
+            {/* Chips resumen */}
+            <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+              <ChipGroup title="Fortalezas" items={item.fortalezas} />
+              <ChipGroup title="Debilidades" items={item.debilidades} />
+              <ChipGroup title="Jugadores clave" items={item.jugadoresClave} />
+              <ChipGroup title="Patrones" items={item.patrones} />
+            </div>
+
+            {item.notas && (
+              <div className="mt-3 text-sm text-gray-700">
+                <span className="font-medium">Notas:</span> {item.notas}
+              </div>
+            )}
+          </div>
+        ))}
+        {items.length === 0 && (
+          <div className="text-sm text-gray-600">Aún no hay rivales para este equipo.</div>
+        )}
+      </div>
+
+      {/* Modal de edición */}
+      {isOpen && form && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/50" onClick={closeModal} />
+          <div className="relative z-10 bg-white rounded-xl shadow-xl w-full max-w-2xl p-4 md:p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-xl font-semibold">Editar rival</h2>
+              <button onClick={closeModal} className="text-gray-500">
+                ✕
+              </button>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm">Nombre del rival *</label>
+                <input
+                  className="border rounded p-2 w-full bg-white text-black"
+                  value={form.rival}
+                  onChange={(e) => setForm({ ...form!, rival: e.target.value })}
+                />
+              </div>
+              <div>
+                <label className="block text-sm">Sistema habitual</label>
+                <input
+                  className="border rounded p-2 w-full bg-white text-black"
+                  placeholder="4-4-2, 4-3-3, 3-5-2…"
+                  value={form.sistemaHabitual || ""}
+                  onChange={(e) =>
+                    setForm({ ...form!, sistemaHabitual: e.target.value })
+                  }
+                />
+              </div>
+
+              <ChipsEditor
+                label="Fortalezas"
+                value={form.fortalezas}
+                onAdd={(v) => addChip("fortalezas", v)}
+                onRemove={(i) => removeChip("fortalezas", i)}
+              />
+              <ChipsEditor
+                label="Debilidades"
+                value={form.debilidades}
+                onAdd={(v) => addChip("debilidades", v)}
+                onRemove={(i) => removeChip("debilidades", i)}
+              />
+              <ChipsEditor
+                label="Jugadores clave"
+                value={form.jugadoresClave}
+                onAdd={(v) => addChip("jugadoresClave", v)}
+                onRemove={(i) => removeChip("jugadoresClave", i)}
+              />
+              <ChipsEditor
+                label="Patrones"
+                value={form.patrones}
+                onAdd={(v) => addChip("patrones", v)}
+                onRemove={(i) => removeChip("patrones", i)}
+              />
+              <div className="md:col-span-2">
+                <label className="block text-sm">Notas</label>
+                <textarea
+                  className="border rounded p-2 w-full min-h-[90px] bg-white text-black"
+                  value={form.notas || ""}
+                  onChange={(e) => setForm({ ...form!, notas: e.target.value })}
+                />
+              </div>
+            </div>
+
+            <div className="mt-6 flex justify-end gap-3">
+              <button onClick={closeModal} className="px-4 py-2 border rounded">
+                Cancelar
+              </button>
+              <button
+                onClick={onSave}
+                className="px-4 py-2 bg-black text-white rounded"
+              >
+                Guardar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Subcomponentes UI
+function Chip({ label, onRemove }: { label: string; onRemove?: () => void }) {
+  return (
+    <span className="inline-flex items-center bg-gray-200 text-gray-700 rounded-full px-2 py-1 mr-2 mb-2">
+      {label}
+      {onRemove && (
+        <button className="ml-1 text-gray-500" onClick={onRemove}>
+          ×
+        </button>
+      )}
+    </span>
+  );
+}
+
+function ChipGroup({ title, items }: { title: string; items: string[] }) {
+  return (
+    <div>
+      <div className="font-medium mb-1">{title}</div>
+      <div className="flex flex-wrap">
+        {items?.length
+          ? items.map((t, i) => <Chip key={i} label={t} />)
+          : <span className="text-gray-500">—</span>}
+      </div>
+    </div>
+  );
+}
+
+function ChipsEditor({
+  label,
+  value,
+  onAdd,
+  onRemove,
+}: {
+  label: string;
+  value: string[];
+  onAdd: (v: string) => void;
+  onRemove: (i: number) => void;
+}) {
+  const [input, setInput] = useState("");
+
+  function add() {
+    const v = input.trim();
+    if (!v) return;
+    onAdd(v);
+    setInput("");
+  }
+
+  function onKey(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      add();
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="text-sm">{label}</label>
+      <div className="flex gap-2">
+        <input
+          className="border rounded p-2 flex-1 bg-white text-black"
+          placeholder={`Añadir a ${label.toLowerCase()}`}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={onKey}
+        />
+        <button
+          type="button"
+          onClick={add}
+          className="px-3 py-2 bg-black text-white rounded"
+        >
+          Añadir
+        </button>
+      </div>
+      <div className="flex flex-wrap">
+        {value?.map((v, i) => (
+          <Chip key={i} label={v} onRemove={() => onRemove(i)} />
+        ))}
+        {!value?.length && (
+          <span className="text-gray-500">Sin elementos</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -337,7 +337,25 @@ export const Toolbar: React.FC<ToolbarProps> = ({
 
       {/* Right Section: Actions */}
       <div className="flex items-center gap-2">
-        <button 
+        <a
+          href="/equipo"
+          className="control-btn"
+        >
+          Equipo
+        </a>
+        <a
+          href="/equipos"
+          className="control-btn"
+        >
+          Equipos
+        </a>
+        <a
+          href="/rivales"
+          className="control-btn"
+        >
+          Rivales
+        </a>
+        <button
           className="control-btn"
           onClick={onShowFormations}
         >

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,46 @@
+import Dexie, { Table } from "dexie";
+import { Player, Squad, OpponentScouting } from "@/types/squad";
+
+export class AppDB extends Dexie {
+  players!: Table<Player, string>;
+  squads!: Table<Squad, string>;
+  opponents!: Table<OpponentScouting, string>;
+  constructor() {
+    super("tacticaDB");
+    // v1: solo jugadores
+    this.version(1).stores({
+      players: "id, dorsal, nombre"
+    });
+    // v2: añadimos squads y los índices por squad
+    this.version(2)
+      .stores({
+        squads: "id, nombre",
+        players: "id, squadId, dorsal, nombre"
+      })
+      .upgrade(async (tx: any) => {
+        const squads = tx.table("squads") as Table<Squad, string>;
+        const players = tx.table("players") as Table<Player, string>;
+        // Asigna squad por defecto a jugadores antiguos si fuera necesario
+        let usedTemp = false;
+        await players.toCollection().modify((p: any) => {
+          if (!p.squadId) { p.squadId = "__DEFAULT_TEMP__"; usedTemp = true; }
+        });
+        if (usedTemp) {
+          const defId = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+          await squads.add({ id: defId, nombre: "Equipo principal" });
+          await players.toCollection().modify((p: any) => {
+            if (p.squadId === "__DEFAULT_TEMP__") p.squadId = defId;
+          });
+        }
+      });
+
+    // v3: nueva tabla opponents
+    this.version(3).stores({
+      squads: "id, nombre",
+      players: "id, squadId, dorsal, nombre",
+      opponents: "id, squadId, rival"
+    });
+  }
+}
+
+export const db = new AppDB();

--- a/src/lib/opponents.ts
+++ b/src/lib/opponents.ts
@@ -1,0 +1,38 @@
+import { db } from "./db";
+import { OpponentScouting } from "@/types/squad";
+
+export async function listOpponents(squadId: string): Promise<OpponentScouting[]> {
+  return db.opponents.where("squadId").equals(squadId).toArray();
+}
+
+export async function createOpponent(squadId: string, rival: string): Promise<OpponentScouting> {
+  if (!rival || !rival.trim()) throw new Error("Nombre del rival obligatorio");
+  const o: OpponentScouting = {
+    id: genId(),
+    squadId,
+    rival: rival.trim(),
+    sistemaHabitual: "",
+    fortalezas: [],
+    debilidades: [],
+    jugadoresClave: [],
+    patrones: [],
+    notas: ""
+  };
+  await db.opponents.add(o);
+  return o;
+}
+
+export async function updateOpponent(id: string, changes: Partial<OpponentScouting>): Promise<void> {
+  await db.opponents.update(id, changes);
+}
+
+export async function deleteOpponent(id: string): Promise<void> {
+  await db.opponents.delete(id);
+}
+
+function genId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    Math.random().toString(36).slice(2)
+  );
+}

--- a/src/lib/players.ts
+++ b/src/lib/players.ts
@@ -1,0 +1,44 @@
+import { db } from "./db";
+import { Player } from "@/types/squad";
+
+export async function listPlayers(squadId: string): Promise<Player[]> {
+  return db.players.where("squadId").equals(squadId).toArray();
+}
+
+export async function createPlayer(
+  squadId: string,
+  p: Omit<Player, "id" | "squadId">
+): Promise<Player> {
+  if (!p.nombre?.trim()) throw new Error("El nombre es obligatorio");
+  if (!Number.isInteger(p.dorsal) || p.dorsal <= 0) throw new Error("Dorsal inválido");
+  if (!p.posiciones?.length) throw new Error("Debe incluir al menos una posición");
+
+  const existing = await db.players
+    .where("squadId")
+    .equals(squadId)
+    .and((pl: Player) => pl.dorsal === p.dorsal)
+    .first();
+  if (existing) throw new Error(`El dorsal ${p.dorsal} ya está en uso en este equipo`);
+
+  const nuevo: Player = { id: genId(), squadId, ...p };
+  await db.players.add(nuevo);
+  return nuevo;
+}
+
+export async function updatePlayer(
+  id: string,
+  changes: Partial<Player>
+): Promise<void> {
+  await db.players.update(id, changes);
+}
+
+export async function deletePlayer(id: string): Promise<void> {
+  await db.players.delete(id);
+}
+
+function genId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    Math.random().toString(36).slice(2)
+  );
+}

--- a/src/lib/squads.ts
+++ b/src/lib/squads.ts
@@ -1,0 +1,57 @@
+import { db } from "./db";
+import { Squad } from "@/types/squad";
+
+const CURRENT_SQUAD_KEY = "tactica.currentSquadId";
+
+export async function listSquads(): Promise<Squad[]> {
+  return db.squads.toArray();
+}
+
+export async function createSquad(nombre: string): Promise<Squad> {
+  const s: Squad = { id: genId(), nombre: nombre.trim() };
+  if (!s.nombre) throw new Error("El nombre es obligatorio");
+  await db.squads.add(s);
+  return s;
+}
+
+export async function renameSquad(id: string, nombre: string): Promise<void> {
+  if (!nombre.trim()) throw new Error("Nombre inválido");
+  await db.squads.update(id, { nombre: nombre.trim() });
+}
+
+export async function deleteSquad(id: string): Promise<void> {
+  const count = await db.players.where("squadId").equals(id).count();
+  if (count > 0) throw new Error("No puedes eliminar un equipo con jugadores");
+  await db.squads.delete(id);
+  const current = getCurrentSquadId();
+  if (current === id) localStorage.removeItem(CURRENT_SQUAD_KEY);
+}
+
+export function setCurrentSquadId(id: string) {
+  localStorage.setItem(CURRENT_SQUAD_KEY, id);
+}
+
+export function getCurrentSquadId(): string | null {
+  return localStorage.getItem(CURRENT_SQUAD_KEY);
+}
+
+export async function ensureCurrentSquad(): Promise<string> {
+  let id = getCurrentSquadId();
+  if (id) return id;
+  const all = await listSquads();
+  if (all.length === 0) {
+    const s = await createSquad("Equipo principal");
+    setCurrentSquadId(s.id);
+    return s.id;
+  }
+  setCurrentSquadId(all[0].id);
+  return all[0].id;
+}
+
+function genId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    Math.random().toString(36).slice(2)
+  );
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './styles/index.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import EquipoPage from './EquipoPage.tsx';
+import EquiposPage from './EquiposPage.tsx';
+import RivalesPage from './RivalesPage.tsx';
+import './styles/index.css';
 
 // Register service worker
 if ('serviceWorker' in navigator) {
@@ -16,8 +19,16 @@ if ('serviceWorker' in navigator) {
   });
 }
 
+const Root = () => {
+  const path = window.location.pathname;
+  if (path.startsWith('/equipos')) return <EquiposPage />;
+  if (path.startsWith('/equipo')) return <EquipoPage />;
+  if (path.startsWith('/rivales')) return <RivalesPage />;
+  return <App />;
+};
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <Root />
   </React.StrictMode>,
 )

--- a/src/types/dexie.d.ts
+++ b/src/types/dexie.d.ts
@@ -1,0 +1,15 @@
+declare module 'dexie' {
+  export default class Dexie {
+    constructor(name: string);
+    version(n: number): any;
+  }
+  export interface Table<T, Key> {
+    add(...args: any[]): Promise<any>;
+    update(...args: any[]): Promise<any>;
+    delete(...args: any[]): Promise<any>;
+    where(...args: any[]): any;
+    toArray(...args: any[]): Promise<T[]>;
+    toCollection(...args: any[]): any;
+    count(...args: any[]): Promise<number>;
+  }
+}

--- a/src/types/squad.ts
+++ b/src/types/squad.ts
@@ -1,0 +1,39 @@
+export type Foot = "diestro" | "zurdo" | "ambidiestro";
+export type Position = "POR"|"LD"|"LI"|"DFC"|"MCD"|"MC"|"MCO"|"ED"|"EI"|"DC"|"SD";
+
+export interface Player {
+  id: string;
+  squadId: string;
+  nombre: string;
+  dorsal: number;
+  pie: Foot;
+  posiciones: Position[];
+  altura_cm?: number;
+  velocidad?: number;
+  resistencia?: number;
+  pase?: number;
+  regate?: number;
+  tiro?: number;
+  defensa?: number;
+  estadoFisico?: number;
+  notas?: string;
+}
+
+export interface Squad {
+  id: string;
+  nombre: string;
+  categoria?: string;
+  temporada?: string;
+}
+
+export interface OpponentScouting {
+  id: string;
+  squadId: string;
+  rival: string;
+  sistemaHabitual?: string;
+  fortalezas: string[];
+  debilidades: string[];
+  jugadoresClave: string[];
+  patrones: string[];
+  notas?: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vercel.json
+++ b/vercel.json
@@ -25,5 +25,8 @@
         }
       ]
     }
+  ],
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
+import { resolve } from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src')
+    }
+  },
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- expand squad types to include opponent scouting info
- migrate Dexie schema to v3 with opponents table
- add rival management page with chips and modal editing

## Testing
- `npm run type-check`
- `npm run build` *(fails: Could not resolve import "dexie" from src/lib/db.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b980433fe08329a3a2b953c7e5b677