### PR TITLE
Use OpenAI API for tactics endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
   },
   "dependencies": {
     "clsx": "^2.0.0",
+    "dexie": "^3.2.4",
+    "openai": "^4.67.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "zustand": "^4.4.7",
-    "dexie": "^3.2.4",
     "uuid": "^9.0.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "^4.4.7"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",


### PR DESCRIPTION
## Summary
- add OpenAI dependency and client setup for tactics route
- replace stubbed AI call with real OpenAI chat completion

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ba2928bd9483298c24c3c05dd416b9