### PR TITLE
Allow scrolling for long player lists

### DIFF
--- a/src/EquipoPage.tsx
+++ b/src/EquipoPage.tsx
@@ -203,7 +203,7 @@ export default function EquipoPage() {
   }
 
   return (
-      <div className="mx-auto max-w-3xl p-4 h-full overflow-y-auto">
+      <div className="mx-auto max-w-3xl p-4 h-full overflow-y-auto touch-pan-y">
         <button onClick={() => window.history.back()} className="mb-4 text-sm underline">
           ← Volver
         </button>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -15,8 +15,8 @@
   
   html {
     font-family: 'Inter', system-ui, sans-serif;
-    touch-action: none; /* Disable all touch gestures */
-    -ms-touch-action: none;
+    touch-action: pan-y; /* Allow vertical scrolling */
+    -ms-touch-action: pan-y;
     -webkit-user-scalable: no;
     user-scalable: no;
   }
@@ -30,8 +30,8 @@
     -webkit-touch-callout: none;
     -webkit-tap-highlight-color: transparent;
     overscroll-behavior: none;
-    touch-action: none; /* Disable all touch gestures including pinch-zoom */
-    -ms-touch-action: none;
+    touch-action: pan-y; /* Allow vertical scrolling while preventing pinch */
+    -ms-touch-action: pan-y;
     -webkit-user-scalable: no;
     user-scalable: no;
     zoom: 1;
@@ -47,8 +47,6 @@
   
   * {
     box-sizing: border-box;
-    touch-action: none; /* Apply to all elements */
-    -ms-touch-action: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- enable vertical scrolling on team player page
- relax global touch-action restrictions to allow scroll

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ba2c2e4cb483299e2daf30a65480a8