### PR TITLE
Handle AI generation errors

### DIFF
--- a/src/PlanesPage.tsx
+++ b/src/PlanesPage.tsx
@@ -123,11 +123,15 @@ export default function PlanesPage() {
     };
 
     const key = simpleHash(JSON.stringify(payload));
-    const ai = await fetchAIResponse(payload);
-    const mapped = mapAIToCanvas(ai);
-    await putTacticsCache({ id: key, createdAt: Date.now(), aiRaw: ai, mapped });
-    sessionStorage.setItem("tactics_to_paint", JSON.stringify({ id: key }));
-    window.location.href = "/tablero";
+    try {
+      const ai = await fetchAIResponse(payload);
+      const mapped = mapAIToCanvas(ai);
+      await putTacticsCache({ id: key, createdAt: Date.now(), aiRaw: ai, mapped });
+      sessionStorage.setItem("tactics_to_paint", JSON.stringify({ id: key }));
+      window.location.href = "/tablero";
+    } catch (e: any) {
+      alert(e.message ?? "Error al generar con IA");
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- show alert when AI generation fails so users know why it doesn't paint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ba2f3e26348329bd9330a97fc51fe9