### PR TITLE
Mejorar mensajes de error al generar tácticas con IA

### DIFF
--- a/app/api/ai/tactics/route.ts
+++ b/app/api/ai/tactics/route.ts
@@ -46,7 +46,13 @@ export async function POST(req: NextRequest) {
     cache.set(key, validated);
     return NextResponse.json(validated, { status: 200 });
   } catch (err: any) {
-    return NextResponse.json({ ok:false, error: err?.message || "Error" }, { status: 400 });
+    const status = err?.status || err?.response?.status || 400;
+    const code = err?.code || err?.error?.code;
+    let message = err?.message || err?.error?.message || "Error";
+    if (code === "insufficient_quota" || status === 402) {
+      message = "Saldo insuficiente en la API de OpenAI";
+    }
+    return NextResponse.json({ ok:false, error: message }, { status });
   }
 }
 

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -8,7 +8,8 @@ export async function fetchAIResponse(payload: any): Promise<AIResponse> {
   });
   if (!res.ok) {
     const err = await res.json().catch(()=>({error:"Error"}));
-    throw new Error(err.error || "Fallo en IA");
+    const msg = err.error || `Fallo en IA (status ${res.status})`;
+    throw new Error(msg);
   }
   return await res.json();
 }


### PR DESCRIPTION
## Summary
- Detallar los fallos al invocar la API de OpenAI y avisar si falta saldo
- Incluir el código de estado HTTP en los errores del cliente de IA

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ba31f09fb0832982bda0acc7b8a020