### PR TITLE
Mejorar mensajes de error al generar tácticas con IA

### DIFF
--- a/app/api/ai/tactics/route.ts
+++ b/app/api/ai/tactics/route.ts
@@ -26,6 +26,13 @@ const AIPayloadSchema = z.object({
 
 const cache = new Map<string, any>();
 
+export function GET() {
+  return NextResponse.json(
+    { ok: false, error: "Método no permitido. Usa POST" },
+    { status: 405 }
+  );
+}
+
 export async function POST(req: NextRequest) {
   try {
     const json = await req.json();
@@ -46,7 +53,13 @@ export async function POST(req: NextRequest) {
     cache.set(key, validated);
     return NextResponse.json(validated, { status: 200 });
   } catch (err: any) {
-    return NextResponse.json({ ok:false, error: err?.message || "Error" }, { status: 400 });
+    const status = err?.status || err?.response?.status || 400;
+    const code = err?.code || err?.error?.code;
+    let message = err?.message || err?.error?.message || "Error";
+    if (code === "insufficient_quota" || status === 402) {
+      message = "Saldo insuficiente en la API de OpenAI";
+    }
+    return NextResponse.json({ ok:false, error: message }, { status });
   }
 }
 

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -7,8 +7,17 @@ export async function fetchAIResponse(payload: any): Promise<AIResponse> {
     body: JSON.stringify(payload)
   });
   if (!res.ok) {
-    const err = await res.json().catch(()=>({error:"Error"}));
-    throw new Error(err.error || "Fallo en IA");
+    let msg = `Fallo en IA (status ${res.status})`;
+    try {
+      const err = await res.json();
+      if (err?.error) msg = err.error;
+    } catch {
+      /* ignore json parse errors */
+    }
+    if (msg === `Fallo en IA (status ${res.status})` && res.status === 405) {
+      msg = "Método HTTP no permitido al invocar la IA";
+    }
+    throw new Error(msg);
   }
   return await res.json();
 }


### PR DESCRIPTION
## Summary
- Detallar los fallos al invocar la API de OpenAI y avisar si falta saldo
- Incluir el código de estado HTTP en los errores del cliente de IA
- Mostrar el código de estado cuando la respuesta de la API no es JSON para evitar mensajes genéricos
- Explicar cuando se usa un método HTTP no permitido al invocar la IA

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ba31f09fb0832982bda0acc7b8a020