### PR TITLE
Display AI tactic data on board page

### DIFF
--- a/src/TableroPage.tsx
+++ b/src/TableroPage.tsx
@@ -1,10 +1,14 @@
 "use client";
+import { useState } from "react";
 import IAListener from "./tablero/IAListener";
 import { CanvasTacticPack } from "@/types/canvas";
 
 export default function TableroPage() {
-  function handlePaint(packs: CanvasTacticPack[]) {
-    const primera = packs[0];
+  const [packs, setPacks] = useState<CanvasTacticPack[]>([]);
+
+  function handlePaint(newPacks: CanvasTacticPack[]) {
+    setPacks(newPacks);
+    const primera = newPacks[0];
     if (primera) {
       // TODO: replace with real board drawing logic
       console.log("Pintando jugada:", primera.titulo, primera.primitivas);
@@ -12,9 +16,30 @@ export default function TableroPage() {
   }
 
   return (
-    <div className="w-full h-full">
-      {/* Aquí iría tu componente de tablero */}
+    <div className="w-full h-full p-4 text-white">
+      {/* Listener que recibe los datos generados por IA */}
       <IAListener onPaint={handlePaint} />
+      {packs.length ? (
+        <div>
+          {packs.map((p, i) => (
+            <div key={i} className="mb-4">
+              <h2 className="text-lg font-semibold mb-2">{p.titulo}</h2>
+              {p.instrucciones?.length > 0 && (
+                <ul className="list-disc ml-5 text-sm mb-2">
+                  {p.instrucciones.map((ins, idx) => (
+                    <li key={idx}>{ins}</li>
+                  ))}
+                </ul>
+              )}
+              <pre className="bg-gray-900 p-2 rounded text-xs overflow-auto">
+                {JSON.stringify(p.primitivas, null, 2)}
+              </pre>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-center mt-10">Esperando jugada de IA...</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show AI-generated tactics on Tablero page to avoid blank screen

## Testing
- `npm test` (fails: Missing script "test")
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68baa8dfcda48329b1db3e5cf71460bd