### PR TITLE
Display AI tactic data on board page

### DIFF
--- a/api/ai/tactics.ts
+++ b/api/ai/tactics.ts
@@ -14,6 +14,16 @@ export default async function handler(req: Request): Promise<Response> {
     });
   }
 
+  if (!process.env.OPENAI_API_KEY) {
+    return new Response(
+      JSON.stringify({ error: "Falta configurar la variable OPENAI_API_KEY" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" }
+      }
+    );
+  }
+
   try {
     const payload = await req.json();
     const systemPrompt = buildSystemPrompt();

--- a/src/TableroPage.tsx
+++ b/src/TableroPage.tsx
@@ -1,10 +1,14 @@
 "use client";
+import { useState } from "react";
 import IAListener from "./tablero/IAListener";
 import { CanvasTacticPack } from "@/types/canvas";
 
 export default function TableroPage() {
-  function handlePaint(packs: CanvasTacticPack[]) {
-    const primera = packs[0];
+  const [packs, setPacks] = useState<CanvasTacticPack[]>([]);
+
+  function handlePaint(newPacks: CanvasTacticPack[]) {
+    setPacks(newPacks);
+    const primera = newPacks[0];
     if (primera) {
       // TODO: replace with real board drawing logic
       console.log("Pintando jugada:", primera.titulo, primera.primitivas);
@@ -12,9 +16,30 @@ export default function TableroPage() {
   }
 
   return (
-    <div className="w-full h-full">
-      {/* Aquí iría tu componente de tablero */}
+    <div className="w-full h-full p-4 text-white">
+      {/* Listener que recibe los datos generados por IA */}
       <IAListener onPaint={handlePaint} />
+      {packs.length ? (
+        <div>
+          {packs.map((p, i) => (
+            <div key={i} className="mb-4">
+              <h2 className="text-lg font-semibold mb-2">{p.titulo}</h2>
+              {p.instrucciones?.length > 0 && (
+                <ul className="list-disc ml-5 text-sm mb-2">
+                  {p.instrucciones.map((ins, idx) => (
+                    <li key={idx}>{ins}</li>
+                  ))}
+                </ul>
+              )}
+              <pre className="bg-gray-900 p-2 rounded text-xs overflow-auto">
+                {JSON.stringify(p.primitivas, null, 2)}
+              </pre>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-center mt-10">Esperando jugada de IA...</p>
+      )}
     </div>
   );
 }

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -1,18 +1,36 @@
 import { AIResponse } from "./types";
 
 export async function fetchAIResponse(payload: any): Promise<AIResponse> {
-  const res = await fetch("/api/ai/tactics", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload)
-  });
+  let res: Response;
+  try {
+    res = await fetch("/api/ai/tactics", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+  } catch (e) {
+    const err = e as Error;
+    throw new Error(`Fallo de red al invocar la IA: ${err.message}`);
+  }
   if (!res.ok) {
     let msg = `Fallo en IA (status ${res.status})`;
+    let text = "";
     try {
-      const err = await res.json();
-      if (err?.error) msg = err.error;
+      text = await res.text();
     } catch {
-      /* ignore json parse errors */
+      /* ignore */
+    }
+    if (text) {
+      try {
+        const err = JSON.parse(text);
+        if (err?.error) {
+          msg = typeof err.error === "string" ? err.error : JSON.stringify(err.error);
+        } else {
+          msg = text;
+        }
+      } catch {
+        msg = text;
+      }
     }
     if (msg === `Fallo en IA (status ${res.status})` && res.status === 405) {
       msg = "Método HTTP no permitido al invocar la IA";


### PR DESCRIPTION
## Summary
- show AI-generated tactics on Tablero page to avoid blank screen
- return clearer error when OPENAI_API_KEY is missing
- improve client-side error handling for AI requests

## Testing
- `npm test` (fails: Missing script "test")
- `npm run type-check` (fails: Cannot find module 'react' or its corresponding type declarations and many implicit any errors)


------
https://chatgpt.com/codex/tasks/task_e_68baa8dfcda48329b1db3e5cf71460bd